### PR TITLE
Return from mpc_ast_print_depth if NULL

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -2603,6 +2603,7 @@ static void mpc_ast_print_depth(mpc_ast_t *a, int d, FILE *fp) {
   
   if (a == NULL) {
     fprintf(fp, "NULL\n");
+    return;
   }
   
   for (i = 0; i < d; i++) { fprintf(fp, "  "); }


### PR DESCRIPTION
Return from mpc_ast_print_depth after printing 'NULL' to avoid the potential segfault.