### PR TITLE
userdata in AST

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -2512,6 +2512,7 @@ void mpc_ast_delete(mpc_ast_t *a) {
     mpc_ast_delete(a->children[i]);
   }
   
+  if (a->free) a->free(a->data);
   free(a->children);
   free(a->tag);
   free(a->contents);
@@ -2520,6 +2521,7 @@ void mpc_ast_delete(mpc_ast_t *a) {
 }
 
 static void mpc_ast_delete_no_children(mpc_ast_t *a) {
+  if (a->free) a->free(a->data);
   free(a->children);
   free(a->tag);
   free(a->contents);

--- a/mpc.h
+++ b/mpc.h
@@ -258,6 +258,8 @@ mpc_parser_t *mpc_re(const char *re);
 typedef struct mpc_ast_t {
   char *tag;
   char *contents;
+  void *data;
+  void (*free)(void*);
   mpc_state_t state;
   int children_num;
   struct mpc_ast_t** children;


### PR DESCRIPTION
mpc doesn't have userdata in AST. so we should parse strings in each times while walking AST.

For example: https://github.com/mattn/orelang/blob/master/ore.c#L1236
since parsing in each times, it's very slow.
