### PR TITLE
Get children by tag

### DIFF
--- a/examples/tree_traversal.c
+++ b/examples/tree_traversal.c
@@ -1,0 +1,73 @@
+#include "../mpc.h"
+
+int main(int argc, char *argv[]) {
+
+    mpc_parser_t *Input  = mpc_new("input");
+    mpc_parser_t *Node  = mpc_new("node");
+    mpc_parser_t *Leaf  = mpc_new("leaf");
+    mpc_ast_t *ast, *tree, *child, *child_sub;
+    mpc_result_t r;
+    int index, lb;
+
+    mpca_lang(MPCA_LANG_PREDICTIVE,
+            " node : '(' <node> ',' /foo/ ',' <node> ')' | <leaf>;"
+            " leaf : /bar/;"
+            " input : /^/ <node> /$/;",
+            Node, Leaf, Input, NULL);
+
+    if (argc > 1) {
+
+        if (mpc_parse_contents(argv[1], Input, &r)) {
+            ast = r.output;
+        } else {
+            mpc_err_print(r.error);
+            mpc_err_delete(r.error);
+            mpc_cleanup(3, Node, Leaf, Input);
+            return EXIT_FAILURE;
+        }
+
+    } else {
+
+        if (mpc_parse_pipe("<stdin>", stdin, Input, &r)) {
+            ast = r.output;
+        } else {
+            mpc_err_print(r.error);
+            mpc_err_delete(r.error);
+            mpc_cleanup(3, Node, Leaf, Input);
+            return EXIT_FAILURE;
+        }
+
+    }
+
+    /* Get index or child of tree */
+    tree = ast->children[1];
+
+    index = mpc_ast_get_index(tree, "node|>");
+    child = mpc_ast_get_child(tree, "node|>");
+
+    if(child == NULL) {
+        mpc_cleanup(3, Node, Leaf, Input);
+        mpc_ast_delete(ast);
+        return EXIT_FAILURE;
+    }
+
+    printf("Index: %d; Child: \"%s\"\n", index, child->tag);
+
+    /* Get multiple indexes or children of trees */
+    index     = mpc_ast_get_index_lb(child, "node|leaf|regex", 0);
+    child_sub = mpc_ast_get_child_lb(child, "node|leaf|regex", 0);
+
+    while(index != -1) {
+        printf("-- Index: %d; Child: \"%s\"\n", index, child_sub->tag);
+
+        lb = index + 1;
+        index     = mpc_ast_get_index_lb(child, "node|leaf|regex", lb);
+        child_sub = mpc_ast_get_child_lb(child, "node|leaf|regex", lb);
+    }
+
+    /* Clean up and return */
+    mpc_cleanup(3, Node, Leaf, Input);
+    mpc_ast_delete(ast);
+
+    return EXIT_SUCCESS;
+}

--- a/examples/tree_traversal.c
+++ b/examples/tree_traversal.c
@@ -2,72 +2,72 @@
 
 int main(int argc, char *argv[]) {
 
-    mpc_parser_t *Input  = mpc_new("input");
-    mpc_parser_t *Node  = mpc_new("node");
-    mpc_parser_t *Leaf  = mpc_new("leaf");
-    mpc_ast_t *ast, *tree, *child, *child_sub;
-    mpc_result_t r;
-    int index, lb;
+  mpc_parser_t *Input  = mpc_new("input");
+  mpc_parser_t *Node  = mpc_new("node");
+  mpc_parser_t *Leaf  = mpc_new("leaf");
+  mpc_ast_t *ast, *tree, *child, *child_sub;
+  mpc_result_t r;
+  int index, lb;
 
-    mpca_lang(MPCA_LANG_PREDICTIVE,
-            " node : '(' <node> ',' /foo/ ',' <node> ')' | <leaf>;"
-            " leaf : /bar/;"
-            " input : /^/ <node> /$/;",
-            Node, Leaf, Input, NULL);
+  mpca_lang(MPCA_LANG_PREDICTIVE,
+        " node : '(' <node> ',' /foo/ ',' <node> ')' | <leaf>;"
+        " leaf : /bar/;"
+        " input : /^/ <node> /$/;",
+        Node, Leaf, Input, NULL);
 
-    if (argc > 1) {
+  if (argc > 1) {
 
-        if (mpc_parse_contents(argv[1], Input, &r)) {
-            ast = r.output;
-        } else {
-            mpc_err_print(r.error);
-            mpc_err_delete(r.error);
-            mpc_cleanup(3, Node, Leaf, Input);
-            return EXIT_FAILURE;
-        }
-
+    if (mpc_parse_contents(argv[1], Input, &r)) {
+      ast = r.output;
     } else {
-
-        if (mpc_parse_pipe("<stdin>", stdin, Input, &r)) {
-            ast = r.output;
-        } else {
-            mpc_err_print(r.error);
-            mpc_err_delete(r.error);
-            mpc_cleanup(3, Node, Leaf, Input);
-            return EXIT_FAILURE;
-        }
-
+      mpc_err_print(r.error);
+      mpc_err_delete(r.error);
+      mpc_cleanup(3, Node, Leaf, Input);
+      return EXIT_FAILURE;
     }
 
-    /* Get index or child of tree */
-    tree = ast->children[1];
+  } else {
 
-    index = mpc_ast_get_index(tree, "node|>");
-    child = mpc_ast_get_child(tree, "node|>");
-
-    if(child == NULL) {
-        mpc_cleanup(3, Node, Leaf, Input);
-        mpc_ast_delete(ast);
-        return EXIT_FAILURE;
+    if (mpc_parse_pipe("<stdin>", stdin, Input, &r)) {
+      ast = r.output;
+    } else {
+      mpc_err_print(r.error);
+      mpc_err_delete(r.error);
+      mpc_cleanup(3, Node, Leaf, Input);
+      return EXIT_FAILURE;
     }
 
-    printf("Index: %d; Child: \"%s\"\n", index, child->tag);
+  }
 
-    /* Get multiple indexes or children of trees */
-    index     = mpc_ast_get_index_lb(child, "node|leaf|regex", 0);
-    child_sub = mpc_ast_get_child_lb(child, "node|leaf|regex", 0);
+  /* Get index or child of tree */
+  tree = ast->children[1];
 
-    while(index != -1) {
-        printf("-- Index: %d; Child: \"%s\"\n", index, child_sub->tag);
+  index = mpc_ast_get_index(tree, "node|>");
+  child = mpc_ast_get_child(tree, "node|>");
 
-        lb = index + 1;
-        index     = mpc_ast_get_index_lb(child, "node|leaf|regex", lb);
-        child_sub = mpc_ast_get_child_lb(child, "node|leaf|regex", lb);
-    }
-
-    /* Clean up and return */
+  if(child == NULL) {
     mpc_cleanup(3, Node, Leaf, Input);
     mpc_ast_delete(ast);
+    return EXIT_FAILURE;
+  }
 
-    return EXIT_SUCCESS;
+  printf("Index: %d; Child: \"%s\"\n", index, child->tag);
+
+  /* Get multiple indexes or children of trees */
+  index     = mpc_ast_get_index_lb(child, "node|leaf|regex", 0);
+  child_sub = mpc_ast_get_child_lb(child, "node|leaf|regex", 0);
+
+  while(index != -1) {
+    printf("-- Index: %d; Child: \"%s\"\n", index, child_sub->tag);
+
+    lb = index + 1;
+    index     = mpc_ast_get_index_lb(child, "node|leaf|regex", lb);
+    child_sub = mpc_ast_get_child_lb(child, "node|leaf|regex", lb);
+  }
+
+  /* Clean up and return */
+  mpc_cleanup(3, Node, Leaf, Input);
+  mpc_ast_delete(ast);
+
+  return EXIT_SUCCESS;
 }

--- a/mpc.c
+++ b/mpc.c
@@ -2776,6 +2776,38 @@ void mpc_ast_print_to(mpc_ast_t *a, FILE *fp) {
   mpc_ast_print_depth(a, 0, fp);
 }
 
+int mpc_ast_get_index(mpc_ast_t *ast, const char *tag) {
+    return mpc_ast_get_index_lb(ast, tag, 0);
+}
+
+int mpc_ast_get_index_lb(mpc_ast_t *ast, const char *tag, int lb) {
+    int i;
+
+    for(i=lb; i<ast->children_num; i++) {
+        if(strcmp(ast->children[i]->tag, tag) == 0) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+mpc_ast_t *mpc_ast_get_child(mpc_ast_t *ast, const char *tag) {
+    return mpc_ast_get_child_lb(ast, tag, 0);
+}
+
+mpc_ast_t *mpc_ast_get_child_lb(mpc_ast_t *ast, const char *tag, int lb) {
+    int i;
+
+    for(i=lb; i<ast->children_num; i++) {
+        if(strcmp(ast->children[i]->tag, tag) == 0) {
+            return ast->children[i];
+        }
+    }
+
+    return NULL;
+}
+
 mpc_val_t *mpcf_fold_ast(int n, mpc_val_t **xs) {
   
   int i, j;

--- a/mpc.c
+++ b/mpc.c
@@ -2777,35 +2777,35 @@ void mpc_ast_print_to(mpc_ast_t *a, FILE *fp) {
 }
 
 int mpc_ast_get_index(mpc_ast_t *ast, const char *tag) {
-    return mpc_ast_get_index_lb(ast, tag, 0);
+  return mpc_ast_get_index_lb(ast, tag, 0);
 }
 
 int mpc_ast_get_index_lb(mpc_ast_t *ast, const char *tag, int lb) {
-    int i;
+  int i;
 
-    for(i=lb; i<ast->children_num; i++) {
-        if(strcmp(ast->children[i]->tag, tag) == 0) {
-            return i;
-        }
+  for(i=lb; i<ast->children_num; i++) {
+    if(strcmp(ast->children[i]->tag, tag) == 0) {
+      return i;
     }
+  }
 
-    return -1;
+  return -1;
 }
 
 mpc_ast_t *mpc_ast_get_child(mpc_ast_t *ast, const char *tag) {
-    return mpc_ast_get_child_lb(ast, tag, 0);
+  return mpc_ast_get_child_lb(ast, tag, 0);
 }
 
 mpc_ast_t *mpc_ast_get_child_lb(mpc_ast_t *ast, const char *tag, int lb) {
-    int i;
+  int i;
 
-    for(i=lb; i<ast->children_num; i++) {
-        if(strcmp(ast->children[i]->tag, tag) == 0) {
-            return ast->children[i];
-        }
+  for(i=lb; i<ast->children_num; i++) {
+    if(strcmp(ast->children[i]->tag, tag) == 0) {
+      return ast->children[i];
     }
+  }
 
-    return NULL;
+  return NULL;
 }
 
 mpc_val_t *mpcf_fold_ast(int n, mpc_val_t **xs) {

--- a/mpc.h
+++ b/mpc.h
@@ -276,6 +276,11 @@ void mpc_ast_delete(mpc_ast_t *a);
 void mpc_ast_print(mpc_ast_t *a);
 void mpc_ast_print_to(mpc_ast_t *a, FILE *fp);
 
+int mpc_ast_get_index(mpc_ast_t *ast, const char *tag);
+int mpc_ast_get_index_lb(mpc_ast_t *ast, const char *tag, int lb);
+mpc_ast_t *mpc_ast_get_child(mpc_ast_t *ast, const char *tag);
+mpc_ast_t *mpc_ast_get_child_lb(mpc_ast_t *ast, const char *tag, int lb);
+
 /*
 ** Warning: This function currently doesn't test for equality of the `state` member!
 */


### PR DESCRIPTION
Regarding issue #45, I've implemented four functions. They are:

```
int mpc_ast_get_index(mpc_ast_t *ast, const char *tag);
int mpc_ast_get_index_lb(mpc_ast_t *ast, const char *tag, int lb);
mpc_ast_t *mpc_ast_get_child(mpc_ast_t *ast, const char *tag);
mpc_ast_t *mpc_ast_get_child_lb(mpc_ast_t *ast, const char *tag, int lb);
```

The first function will return the index of of the child given the tag of the child. The second is similar but returns a pointer to the child and not the index. The tag is compared using the function `strcmp`.

The third and fourth functions are similar, but they have a third parameter called lower bound `lb`. This parameters gives a minimum index from which the child node will be looked for in the array of children of a given node.

I've added an example to display the usage of this function.