### PR TITLE
Add newline to end of ptest.h

### DIFF
--- a/tests/ptest.h
+++ b/tests/ptest.h
@@ -19,3 +19,4 @@ void pt_add_suite(void (*func)(void));
 int pt_run(void);
 
 #endif
+


### PR DESCRIPTION
Add newline to end of `tests/ptest.h` To fix warnings (on OSX):

```
$ make
gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/doge.c mpc.c -lm -o examples/doge
gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/foobar.c mpc.c -lm -o examples/foobar
gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/lispy.c mpc.c -lm -o examples/lispy
gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/maths.c mpc.c -lm -o examples/maths
gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/smallc.c mpc.c -lm -o examples/smallc
gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/tree_traversal.c mpc.c -lm -o examples/tree_traversal
gcc -ansi -pedantic -O3 -g -Wall -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default tests/core.c tests/grammar.c tests/ptest.c tests/regex.c tests/test.c mpc.c -lm -o test
In file included from tests/core.c:1:
tests/ptest.h:21:7: warning: no newline at end of file [-Wnewline-eof]
#endif
      ^
1 warning generated.
In file included from tests/grammar.c:1:
tests/ptest.h:21:7: warning: no newline at end of file [-Wnewline-eof]
#endif
      ^
1 warning generated.
In file included from tests/ptest.c:1:
tests/ptest.h:21:7: warning: no newline at end of file [-Wnewline-eof]
#endif
      ^
1 warning generated.
In file included from tests/regex.c:1:
tests/ptest.h:21:7: warning: no newline at end of file [-Wnewline-eof]
#endif
      ^
1 warning generated.
In file included from tests/test.c:1:
tests/ptest.h:21:7: warning: no newline at end of file [-Wnewline-eof]
#endif
      ^
1 warning generated.
./test

    +-------------------------------------------+
    | ptest          MicroTesting Magic for C   |
    |                                           |
    | http://github.com/orangeduck/ptest        |
    |                                           |
    | Daniel Holden (contact@theorangeduck.com) |
    +-------------------------------------------+


  ===== Suite Core =====

    | Test Ident ... Passed!
    | Test Maths ... Passed!
    | Test Strip ... Passed!
    | Test Repeat ... Passed!
    | Test Copy ... Passed!


  ===== Suite Regex =====

    | Test Regex Basic ... Passed!
    | Test Regex Range ... Passed!
    | Test Regex String ... Passed!
    | Test Regex Lisp Comment ... Passed!
    | Test Regex Boundary ... Passed!


  ===== Suite Grammar =====

    | Test Grammar ... Passed!
    | Test Language ... Passed!
    | Test Language File ... Passed!
    | Test Doge ... Passed!
    | Test Partial ... Passed!
    | Test QScript ... Passed!
    | Test Missing Rule ... Passed!

  +---------------------------------------------------+
  |                      Summary                      |
  +---------++------------+-------------+-------------+
  | Suites  || Total    3 | Passed    3 | Failed    0 |
  | Tests   || Total   17 | Passed   17 | Failed    0 |
  | Asserts || Total   76 | Passed   76 | Failed    0 |
  +---------++------------+-------------+-------------+

      Total Running Time: 0.006s

```



