### PR TITLE
fix build error with gcc 5.4

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -2256,7 +2256,7 @@ mpc_val_t *mpcf_oct(mpc_val_t *x) {
 
 mpc_val_t *mpcf_float(mpc_val_t *x) {
   float *y = malloc(sizeof(float));
-  *y = strtof(x, NULL);
+  *y = strtod(x, NULL);
   free(x);
   return y;
 }


### PR DESCRIPTION
In Ubuntu 16.04,I build mpc with gcc 5.4, I find some errors: 

> mpc.c: In function ‘mpcf_float’:
mpc.c:2259:8: error: implicit declaration of function ‘strtof’ [-Werror=implicit-function-declaration]
   *y = strtof(x, NULL);
        ^
mpc.c:2259:3: error: nested extern declaration of ‘strtof’ [-Werror=nested-externs]
   *y = strtof(x, NULL);

so,I think the strtod is better than strtof.
