### PR TITLE
Add `mpc_check` and `mpc_check_with` combinators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,15 @@ Returns a parser that applies function `f` (optionality taking extra input `x`) 
 * * *
 
 ```c
+mpc_parser_t *mpc_check(mpc_parser_t *a, mpc_check_t f, const char *e);
+mpc_parser_t *mpc_check_with(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *e);
+```
+
+Returns a parser that applies function `f` (optionally taking extra input `x`) to the result of parser `a`. If `f` returns non-zero, then the parser succeeds and returns the value of `a` (possibly modified by `f`). If `f` returns zero, then the parser fails with message `e`.
+
+* * *
+
+```c
 mpc_parser_t *mpc_not(mpc_parser_t *a, mpc_dtor_t da);
 mpc_parser_t *mpc_not_lift(mpc_parser_t *a, mpc_dtor_t da, mpc_ctor_t lf);
 ```
@@ -407,6 +416,15 @@ typedef mpc_val_t*(*mpc_apply_to_t)(mpc_val_t*,void*);
 ```
 
 This takes in some pointer to data and outputs some new or modified pointer to data, ensuring to free the input data if it is no longer used. The `apply_to` variation takes in an extra pointer to some data such as global state.
+
+* * *
+
+```c
+typedef int(*mpc_check_t)(mpc_val_t**);
+typedef int(*mpc_check_with_t)(mpc_val_t**,void*);
+```
+
+This takes in some pointer to data and outputs 0 if parsing should stop with an error. Additionally, this may change or free the input data. The `check_with` variation takes in an extra pointer to some data such as global state.
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Returns a parser that applies function `f` (optionality taking extra input `x`) 
 ```c
 mpc_parser_t *mpc_check(mpc_parser_t *a, mpc_check_t f, const char *e);
 mpc_parser_t *mpc_check_with(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *e);
+mpc_parser_t *mpc_checkf(mpc_parser_t *a, mpc_check_t f, const char *fmt, ...);
+mpc_parser_t *mpc_check_withf(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *fmt, ...);
 ```
 
 Returns a parser that applies function `f` (optionally taking extra input `x`) to the result of parser `a`. If `f` returns non-zero, then the parser succeeds and returns the value of `a` (possibly modified by `f`). If `f` returns zero, then the parser fails with message `e`.

--- a/mpc.c
+++ b/mpc.c
@@ -1790,6 +1790,38 @@ mpc_parser_t *mpc_check_with(mpc_parser_t *a, mpc_check_with_t f, void *x, const
   return p;
 }
 
+mpc_parser_t *mpc_checkf(mpc_parser_t *a, mpc_check_t f, const char *fmt, ...) {
+  va_list        va;
+  char          *buffer;
+  mpc_parser_t  *p;
+
+  va_start(va, fmt);
+  buffer = malloc(2048);
+  vsprintf(buffer, fmt, va);
+  va_end(va);
+
+  p = mpc_check (a, f, buffer);
+  free (buffer);
+
+  return p;
+}
+
+mpc_parser_t *mpc_check_withf(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *fmt, ...) {
+  va_list        va;
+  char          *buffer;
+  mpc_parser_t  *p;
+
+  va_start(va, fmt);
+  buffer = malloc(2048);
+  vsprintf(buffer, fmt, va);
+  va_end(va);
+
+  p = mpc_check_with (a, f, x, buffer);
+  free (buffer);
+
+  return p;
+}
+
 mpc_parser_t *mpc_predictive(mpc_parser_t *a) {
   mpc_parser_t *p = mpc_undefined();
   p->type = MPC_TYPE_PREDICT;

--- a/mpc.c
+++ b/mpc.c
@@ -855,34 +855,37 @@ static mpc_err_t *mpc_err_merge(mpc_input_t *i, mpc_err_t *x, mpc_err_t *y) {
 */
 
 enum {
-  MPC_TYPE_UNDEFINED = 0,
-  MPC_TYPE_PASS      = 1,
-  MPC_TYPE_FAIL      = 2,
-  MPC_TYPE_LIFT      = 3,
-  MPC_TYPE_LIFT_VAL  = 4,
-  MPC_TYPE_EXPECT    = 5,
-  MPC_TYPE_ANCHOR    = 6,
-  MPC_TYPE_STATE     = 7,
-  
-  MPC_TYPE_ANY       = 8,
-  MPC_TYPE_SINGLE    = 9,
-  MPC_TYPE_ONEOF     = 10,
-  MPC_TYPE_NONEOF    = 11,
-  MPC_TYPE_RANGE     = 12,
-  MPC_TYPE_SATISFY   = 13,
-  MPC_TYPE_STRING    = 14,
-  
-  MPC_TYPE_APPLY     = 15,
-  MPC_TYPE_APPLY_TO  = 16,
-  MPC_TYPE_PREDICT   = 17,
-  MPC_TYPE_NOT       = 18,
-  MPC_TYPE_MAYBE     = 19,
-  MPC_TYPE_MANY      = 20,
-  MPC_TYPE_MANY1     = 21,
-  MPC_TYPE_COUNT     = 22,
-  
-  MPC_TYPE_OR        = 23,
-  MPC_TYPE_AND       = 24
+  MPC_TYPE_UNDEFINED  = 0,
+  MPC_TYPE_PASS       = 1,
+  MPC_TYPE_FAIL       = 2,
+  MPC_TYPE_LIFT       = 3,
+  MPC_TYPE_LIFT_VAL   = 4,
+  MPC_TYPE_EXPECT     = 5,
+  MPC_TYPE_ANCHOR     = 6,
+  MPC_TYPE_STATE      = 7,
+
+  MPC_TYPE_ANY        = 8,
+  MPC_TYPE_SINGLE     = 9,
+  MPC_TYPE_ONEOF      = 10,
+  MPC_TYPE_NONEOF     = 11,
+  MPC_TYPE_RANGE      = 12,
+  MPC_TYPE_SATISFY    = 13,
+  MPC_TYPE_STRING     = 14,
+
+  MPC_TYPE_APPLY      = 15,
+  MPC_TYPE_APPLY_TO   = 16,
+  MPC_TYPE_PREDICT    = 17,
+  MPC_TYPE_NOT        = 18,
+  MPC_TYPE_MAYBE      = 19,
+  MPC_TYPE_MANY       = 20,
+  MPC_TYPE_MANY1      = 21,
+  MPC_TYPE_COUNT      = 22,
+
+  MPC_TYPE_OR         = 23,
+  MPC_TYPE_AND        = 24,
+
+  MPC_TYPE_CHECK      = 25,
+  MPC_TYPE_CHECK_WITH = 26,
 };
 
 typedef struct { char *m; } mpc_pdata_fail_t;
@@ -895,6 +898,8 @@ typedef struct { int(*f)(char); } mpc_pdata_satisfy_t;
 typedef struct { char *x; } mpc_pdata_string_t;
 typedef struct { mpc_parser_t *x; mpc_apply_t f; } mpc_pdata_apply_t;
 typedef struct { mpc_parser_t *x; mpc_apply_to_t f; void *d; } mpc_pdata_apply_to_t;
+typedef struct { mpc_parser_t *x; mpc_check_t f; char *e; } mpc_pdata_check_t;
+typedef struct { mpc_parser_t *x; mpc_check_with_t f; void *d; char *e; } mpc_pdata_check_with_t;
 typedef struct { mpc_parser_t *x; } mpc_pdata_predict_t;
 typedef struct { mpc_parser_t *x; mpc_dtor_t dx; mpc_ctor_t lf; } mpc_pdata_not_t;
 typedef struct { int n; mpc_fold_t f; mpc_parser_t *x; mpc_dtor_t dx; } mpc_pdata_repeat_t;
@@ -912,6 +917,8 @@ typedef union {
   mpc_pdata_string_t string;
   mpc_pdata_apply_t apply;
   mpc_pdata_apply_to_t apply_to;
+  mpc_pdata_check_t check;
+  mpc_pdata_check_with_t check_with;
   mpc_pdata_predict_t predict;
   mpc_pdata_not_t not;
   mpc_pdata_repeat_t repeat;
@@ -1050,7 +1057,29 @@ static int mpc_parse_run(mpc_input_t *i, mpc_parser_t *p, mpc_result_t *r, mpc_e
       } else {
         MPC_FAILURE(r->error);
       }
-    
+
+    case MPC_TYPE_CHECK:
+      if (mpc_parse_run(i, p->data.check.x, r, e)) {
+        if (p->data.check.f(&r->output)) {
+          MPC_SUCCESS(r->output);
+        } else {
+          MPC_FAILURE(mpc_err_fail(i, p->data.check.e));
+        }
+      } else {
+        MPC_FAILURE(r->error);
+      }
+
+    case MPC_TYPE_CHECK_WITH:
+      if (mpc_parse_run(i, p->data.check_with.x, r, e)) {
+        if (p->data.check_with.f(&r->output, p->data.check_with.d)) {
+          MPC_SUCCESS(r->output);
+        } else {
+          MPC_FAILURE(mpc_err_fail(i, p->data.check_with.e));
+        }
+      } else {
+        MPC_FAILURE(r->error);
+      }
+
     case MPC_TYPE_EXPECT:
       mpc_input_suppress_enable(i);
       if (mpc_parse_run(i, p->data.expect.x, r, e)) {
@@ -1358,6 +1387,16 @@ static void mpc_undefine_unretained(mpc_parser_t *p, int force) {
     case MPC_TYPE_OR:  mpc_undefine_or(p);  break;
     case MPC_TYPE_AND: mpc_undefine_and(p); break;
     
+    case MPC_TYPE_CHECK:
+      mpc_undefine_unretained(p->data.check.x, 0);
+      free(p->data.check.e);
+      break;
+
+    case MPC_TYPE_CHECK_WITH:
+      mpc_undefine_unretained(p->data.check_with.x, 0);
+      free(p->data.check_with.e);
+      break;
+
     default: break;
   }
   
@@ -1471,6 +1510,17 @@ mpc_parser_t *mpc_copy(mpc_parser_t *a) {
       }
     break;
     
+    case MPC_TYPE_CHECK:
+      p->data.check.x      = mpc_copy(a->data.check.x);
+      p->data.check.e      = malloc(strlen(a->data.check.e)+1);
+      strcpy(p->data.check.e, a->data.check.e);
+      break;
+    case MPC_TYPE_CHECK_WITH:
+      p->data.check_with.x = mpc_copy(a->data.check_with.x);
+      p->data.check_with.e = malloc(strlen(a->data.check_with.e)+1);
+      strcpy(p->data.check_with.e, a->data.check_with.e);
+      break;
+
     default: break;
   }
 
@@ -1716,6 +1766,27 @@ mpc_parser_t *mpc_apply_to(mpc_parser_t *a, mpc_apply_to_t f, void *x) {
   p->data.apply_to.x = a;
   p->data.apply_to.f = f;
   p->data.apply_to.d = x;
+  return p;
+}
+
+mpc_parser_t *mpc_check(mpc_parser_t *a, mpc_check_t f, const char *e) {
+  mpc_parser_t  *p = mpc_undefined();
+  p->type          = MPC_TYPE_CHECK;
+  p->data.check.x  = a;
+  p->data.check.f  = f;
+  p->data.check.e  = malloc(strlen(e) + 1);
+  strcpy(p->data.check.e, e);
+  return p;
+}
+
+mpc_parser_t *mpc_check_with(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *e) {
+  mpc_parser_t  *p     = mpc_undefined();
+  p->type              = MPC_TYPE_CHECK_WITH;
+  p->data.check_with.x = a;
+  p->data.check_with.f = f;
+  p->data.check_with.d = x;
+  p->data.check_with.e = malloc(strlen(e) + 1);
+  strcpy(p->data.check_with.e, e);
   return p;
 }
 
@@ -2595,7 +2666,16 @@ static void mpc_print_unretained(mpc_parser_t *p, int force) {
     mpc_print_unretained(p->data.and.xs[p->data.and.n-1], 0);
     printf(")");
   }
-  
+
+  if (p->type == MPC_TYPE_CHECK) {
+    mpc_print_unretained(p->data.check.x, 0);
+    printf("->?");
+  }
+  if (p->type == MPC_TYPE_CHECK_WITH) {
+    mpc_print_unretained(p->data.check_with.x, 0);
+    printf("->?");
+  }
+
 }
 
 void mpc_print(mpc_parser_t *p) {
@@ -3636,6 +3716,9 @@ static int mpc_nodecount_unretained(mpc_parser_t* p, int force) {
   if (p->type == MPC_TYPE_APPLY_TO) { return 1 + mpc_nodecount_unretained(p->data.apply_to.x, 0); }
   if (p->type == MPC_TYPE_PREDICT)  { return 1 + mpc_nodecount_unretained(p->data.predict.x, 0); }
 
+  if (p->type == MPC_TYPE_CHECK)    { return 1 + mpc_nodecount_unretained(p->data.check.x, 0); }
+  if (p->type == MPC_TYPE_CHECK_WITH) { return 1 + mpc_nodecount_unretained(p->data.check_with.x, 0); }
+
   if (p->type == MPC_TYPE_NOT)   { return 1 + mpc_nodecount_unretained(p->data.not.x, 0); }
   if (p->type == MPC_TYPE_MAYBE) { return 1 + mpc_nodecount_unretained(p->data.not.x, 0); }
 
@@ -3678,15 +3761,17 @@ static void mpc_optimise_unretained(mpc_parser_t *p, int force) {
   
   /* Optimise Subexpressions */
   
-  if (p->type == MPC_TYPE_EXPECT)   { mpc_optimise_unretained(p->data.expect.x, 0); }
-  if (p->type == MPC_TYPE_APPLY)    { mpc_optimise_unretained(p->data.apply.x, 0); }
-  if (p->type == MPC_TYPE_APPLY_TO) { mpc_optimise_unretained(p->data.apply_to.x, 0); }
-  if (p->type == MPC_TYPE_PREDICT)  { mpc_optimise_unretained(p->data.predict.x, 0); }
-  if (p->type == MPC_TYPE_NOT)      { mpc_optimise_unretained(p->data.not.x, 0); }
-  if (p->type == MPC_TYPE_MAYBE)    { mpc_optimise_unretained(p->data.not.x, 0); }
-  if (p->type == MPC_TYPE_MANY)     { mpc_optimise_unretained(p->data.repeat.x, 0); }
-  if (p->type == MPC_TYPE_MANY1)    { mpc_optimise_unretained(p->data.repeat.x, 0); }
-  if (p->type == MPC_TYPE_COUNT)    { mpc_optimise_unretained(p->data.repeat.x, 0); }
+  if (p->type == MPC_TYPE_EXPECT)     { mpc_optimise_unretained(p->data.expect.x, 0); }
+  if (p->type == MPC_TYPE_APPLY)      { mpc_optimise_unretained(p->data.apply.x, 0); }
+  if (p->type == MPC_TYPE_APPLY_TO)   { mpc_optimise_unretained(p->data.apply_to.x, 0); }
+  if (p->type == MPC_TYPE_CHECK)      { mpc_optimise_unretained(p->data.check.x, 0); }
+  if (p->type == MPC_TYPE_CHECK_WITH) { mpc_optimise_unretained(p->data.check_with.x, 0); }
+  if (p->type == MPC_TYPE_PREDICT)    { mpc_optimise_unretained(p->data.predict.x, 0); }
+  if (p->type == MPC_TYPE_NOT)        { mpc_optimise_unretained(p->data.not.x, 0); }
+  if (p->type == MPC_TYPE_MAYBE)      { mpc_optimise_unretained(p->data.not.x, 0); }
+  if (p->type == MPC_TYPE_MANY)       { mpc_optimise_unretained(p->data.repeat.x, 0); }
+  if (p->type == MPC_TYPE_MANY1)      { mpc_optimise_unretained(p->data.repeat.x, 0); }
+  if (p->type == MPC_TYPE_COUNT)      { mpc_optimise_unretained(p->data.repeat.x, 0); }
   
   if (p->type == MPC_TYPE_OR) { 
     for(i = 0; i < p->data.or.n; i++) {

--- a/mpc.h
+++ b/mpc.h
@@ -130,6 +130,8 @@ mpc_parser_t *mpc_apply(mpc_parser_t *a, mpc_apply_t f);
 mpc_parser_t *mpc_apply_to(mpc_parser_t *a, mpc_apply_to_t f, void *x);
 mpc_parser_t *mpc_check(mpc_parser_t *a, mpc_check_t f, const char *e);
 mpc_parser_t *mpc_check_with(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *e);
+mpc_parser_t *mpc_checkf(mpc_parser_t *a, mpc_check_t f, const char *fmt, ...);
+mpc_parser_t *mpc_check_withf(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *fmt, ...);
 
 mpc_parser_t *mpc_not(mpc_parser_t *a, mpc_dtor_t da);
 mpc_parser_t *mpc_not_lift(mpc_parser_t *a, mpc_dtor_t da, mpc_ctor_t lf);

--- a/mpc.h
+++ b/mpc.h
@@ -81,6 +81,9 @@ typedef mpc_val_t*(*mpc_apply_t)(mpc_val_t*);
 typedef mpc_val_t*(*mpc_apply_to_t)(mpc_val_t*,void*);
 typedef mpc_val_t*(*mpc_fold_t)(int,mpc_val_t**);
 
+typedef int(*mpc_check_t)(mpc_val_t**);
+typedef int(*mpc_check_with_t)(mpc_val_t**,void*);
+
 /*
 ** Building a Parser
 */
@@ -125,6 +128,8 @@ mpc_parser_t *mpc_expect(mpc_parser_t *a, const char *e);
 mpc_parser_t *mpc_expectf(mpc_parser_t *a, const char *fmt, ...);
 mpc_parser_t *mpc_apply(mpc_parser_t *a, mpc_apply_t f);
 mpc_parser_t *mpc_apply_to(mpc_parser_t *a, mpc_apply_to_t f, void *x);
+mpc_parser_t *mpc_check(mpc_parser_t *a, mpc_check_t f, const char *e);
+mpc_parser_t *mpc_check_with(mpc_parser_t *a, mpc_check_with_t f, void *x, const char *e);
 
 mpc_parser_t *mpc_not(mpc_parser_t *a, mpc_dtor_t da);
 mpc_parser_t *mpc_not_lift(mpc_parser_t *a, mpc_dtor_t da, mpc_ctor_t lf);

--- a/tests/combinators.c
+++ b/tests/combinators.c
@@ -1,0 +1,51 @@
+#include "ptest.h"
+#include "../mpc.h"
+
+static int check_is_a(mpc_val_t** x) {
+  return strcmp(*x, "a") == 0;
+}
+
+static int check_is(mpc_val_t** x, void* t) {
+  return strcmp(*x, t) == 0;
+}
+
+void test_check(void) {
+  int           success;
+  mpc_result_t  r;
+  mpc_parser_t* p = mpc_check(mpc_or(2, mpc_char('a'), mpc_char('b')), check_is_a, "Expected 'a'");
+
+  success = mpc_parse("test", "a", p, &r);
+  PT_ASSERT(success);
+  PT_ASSERT_STR_EQ(r.output, "a");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  success = mpc_parse("test", "b", p, &r);
+  PT_ASSERT(!success);
+  PT_ASSERT_STR_EQ(r.error->failure, "Expected 'a'");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  mpc_delete(p);
+}
+
+void test_check_with(void) {
+  int           success;
+  mpc_result_t  r;
+  mpc_parser_t* p = mpc_check_with(mpc_or(2, mpc_char('a'), mpc_char('b')), check_is, "a", "Expected 'a'");
+
+  success = mpc_parse("test", "a", p, &r);
+  PT_ASSERT(success);
+  if (success) PT_ASSERT_STR_EQ(r.output, "a");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  success = mpc_parse("test", "b", p, &r);
+  PT_ASSERT(!success);
+  if (!success) PT_ASSERT_STR_EQ(r.error->failure, "Expected 'a'");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  mpc_delete(p);
+}
+
+void suite_combinators(void) {
+  pt_add_test(test_check,      "Test Check",      "Suite Combinators");
+  pt_add_test(test_check_with, "Test Check with", "Suite Combinators");
+}

--- a/tests/combinators.c
+++ b/tests/combinators.c
@@ -45,6 +45,42 @@ void test_check_with(void) {
   mpc_delete(p);
 }
 
+void test_checkf(void) {
+  int           success;
+  mpc_result_t  r;
+  mpc_parser_t* p = mpc_checkf(mpc_or(2, mpc_char('a'), mpc_char('b')), check_is_a, "Expected '%s'", "a");
+
+  success = mpc_parse("test", "a", p, &r);
+  PT_ASSERT(success);
+  PT_ASSERT_STR_EQ(r.output, "a");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  success = mpc_parse("test", "b", p, &r);
+  PT_ASSERT(!success);
+  PT_ASSERT_STR_EQ(r.error->failure, "Expected 'a'");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  mpc_delete(p);
+}
+
+void test_check_withf(void) {
+  int           success;
+  mpc_result_t  r;
+  mpc_parser_t* p = mpc_check_withf(mpc_or(2, mpc_char('a'), mpc_char('b')), check_is, "a", "Expected '%s'", "a");
+
+  success = mpc_parse("test", "a", p, &r);
+  PT_ASSERT(success);
+  if (success) PT_ASSERT_STR_EQ(r.output, "a");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  success = mpc_parse("test", "b", p, &r);
+  PT_ASSERT(!success);
+  if (!success) PT_ASSERT_STR_EQ(r.error->failure, "Expected 'a'");
+  if (success) free(r.output); else mpc_err_delete(r.error);
+
+  mpc_delete(p);
+}
+
 void suite_combinators(void) {
   pt_add_test(test_check,      "Test Check",      "Suite Combinators");
   pt_add_test(test_check_with, "Test Check with", "Suite Combinators");

--- a/tests/combinators.c
+++ b/tests/combinators.c
@@ -82,6 +82,8 @@ void test_check_withf(void) {
 }
 
 void suite_combinators(void) {
-  pt_add_test(test_check,      "Test Check",      "Suite Combinators");
-  pt_add_test(test_check_with, "Test Check with", "Suite Combinators");
+  pt_add_test(test_check,       "Test Check",        "Suite Combinators");
+  pt_add_test(test_check_with,  "Test Check with",   "Suite Combinators");
+  pt_add_test(test_checkf,      "Test Check F",      "Suite Combinators");
+  pt_add_test(test_check_withf, "Test Check with F", "Suite Combinators");
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -3,12 +3,14 @@
 void suite_core(void);
 void suite_regex(void);
 void suite_grammar(void);
+void suite_combinators(void);
 
 int main(int argc, char** argv) {
   (void) argc; (void) argv;
   pt_add_suite(suite_core);
   pt_add_suite(suite_regex);
   pt_add_suite(suite_grammar);
+  pt_add_suite(suite_combinators);
   return pt_run();
 }
 


### PR DESCRIPTION
Those combinators allow checking for arbitrary conditions during parsing and stopping the parse early if a condition is not met. For example, they can be used in a toy language to stop immediately if the user tries to define an identifier more than once.