### PR TITLE
Fix minor memory leak, fix non-compliance with ANSI standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CC = gcc
-STND=-ansi
+STND=-std=c99
 CFLAGS = $(STND) -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow \
   -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align \
   -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CC = gcc
-STND=-std=c99
+STND=-ansi
 CFLAGS = $(STND) -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow \
   -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align \
   -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls \

--- a/mpc.c
+++ b/mpc.c
@@ -2210,9 +2210,9 @@ static mpc_val_t *mpcf_re_range(mpc_val_t *x) {
   int comp = s[0] == '^' ? 1 : 0;
   char *range = calloc(1,1);
   
-  if (s[0] == '\0') { free(x); return mpc_fail("Invalid Regex Range Expression"); } 
+  if (s[0] == '\0') { free(range); free(x); return mpc_fail("Invalid Regex Range Expression"); } 
   if (s[0] == '^' && 
-      s[1] == '\0') { free(x); return mpc_fail("Invalid Regex Range Expression"); }
+      s[1] == '\0') { free(range); free(x); return mpc_fail("Invalid Regex Range Expression"); }
   
   for (i = comp; i < strlen(s); i++){
     

--- a/mpc.c
+++ b/mpc.c
@@ -885,7 +885,7 @@ enum {
   MPC_TYPE_AND        = 24,
 
   MPC_TYPE_CHECK      = 25,
-  MPC_TYPE_CHECK_WITH = 26,
+  MPC_TYPE_CHECK_WITH = 26
 };
 
 typedef struct { char *m; } mpc_pdata_fail_t;


### PR DESCRIPTION
Two minor fixes, the comment says it all. 

Of note, the standard in the Makefile is wrong, I get the following error when trying to compile:

	make
	gcc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow
	-Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align
	-Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls
	-Wnested-externs -Wmissing-include-dirs -Wswitch-default examples/maths.c mpc.c
	-lm -o examples/maths
	mpc.c:888:27: error: comma at end of enumerator list [-Werror=pedantic]
	   MPC_TYPE_CHECK_WITH = 26,
				   ^
	cc1: all warnings being treated as errors
	Makefile:20: recipe for target 'examples/maths' failed
	make: *** [examples/maths] Error 1

I don't believe trailing commas are allowed in ANSI-C.