### PR TITLE
Dramatically update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,11 @@ examples/%: $(DIST) examples/%.c $(PROJ).c
 	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
 
 lib$(PROJ).so: $(DIST) $(PROJ).c
+ifneq ($(OS),Windows_NT)
 	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+else
+	$(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+endif
 
 lib$(PROJ).a: $(DIST) $(PROJ).c
 	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROJ = mpc
 CC ?= gcc
 STND = -ansi
 DIST = build
+MKDIR  ?= mkdir -p
 PREFIX ?= /usr/local
 CFLAGS ?= $(STND) -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow \
   -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align \
@@ -17,7 +18,7 @@ EXAMPLESEXE = $(EXAMPLES:.c=)
 all: $(EXAMPLESEXE) check
 
 $(DIST):
-	mkdir -p $(DIST)/examples
+	$(MKDIR) $(DIST)/examples
 
 check: test-file test-static test-dynamic
 	./$(DIST)/test-file
@@ -41,7 +42,7 @@ lib$(PROJ).so: $(DIST) $(PROJ).c
 
 lib$(PROJ).a: $(DIST) $(PROJ).c
 	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
-	ar rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
+	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
 libs: lib$(PROJ).so lib$(PROJ).a
   

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-
-CC = gcc
-STND=-ansi
-CFLAGS = $(STND) -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow \
+PROJ = mpc
+CC ?= gcc
+STND = -ansi
+DIST = build
+PREFIX ?= /usr/local
+CFLAGS ?= $(STND) -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow \
   -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align \
   -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls \
   -Wnested-externs -Wmissing-include-dirs -Wswitch-default
@@ -10,15 +12,50 @@ TESTS = $(wildcard tests/*.c)
 EXAMPLES = $(wildcard examples/*.c)
 EXAMPLESEXE = $(EXAMPLES:.c=)
 
-all: $(EXAMPLESEXE) check 
+.PHONY: all check clean libs
 
-check: $(TESTS) mpc.c
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $^ -lm -o test
-	./test
+all: $(EXAMPLESEXE) check
 
-examples/%: examples/%.c mpc.c
-	$(CC) $(CFLAGS) $^ -lm -o $@
+$(DIST):
+	mkdir -p $(DIST)/examples
+
+check: test-file test-static test-dynamic
+	./$(DIST)/test-file
+	./$(DIST)/test-static
+	LD_LIBRARY_PATH=$(DIST) ./$(DIST)/test-dynamic
+
+test-file: $(DIST) $(TESTS) $(PROJ).c
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
+
+test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
+
+test-static: $(DIST) $(TESTS) lib$(PROJ).a
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
+
+examples/%: $(DIST) examples/%.c $(PROJ).c
+	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
+
+lib$(PROJ).so: $(DIST) $(PROJ).c
+	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+
+lib$(PROJ).a: $(DIST) $(PROJ).c
+	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
+	ar rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
+
+libs: lib$(PROJ).so lib$(PROJ).a
   
 clean:
-	rm -rf test examples/doge examples/lispy examples/maths examples/smallc \
-	examples/foobar examples/tree_traversal
+	rm -rf -- $(DIST)
+
+install: all
+	install -d -m644 $(DESTDIR)$(PREFIX)/{include,lib,share/$(PROJ)}
+	install -m755 -t $(DESTDIR)$(PREFIX)/lib $(DIST)/lib*
+	install -m644 -t $(DESTDIR)$(PREFIX)/share/$(PROJ) $(PROJ).{c,h}
+	install -m644 $(PROJ).h $(DESTDIR)$(PREFIX)/include/$(PROJ).h
+
+uninstall:
+	rm -rf -- \
+		$(DESTDIR)$(PREFIX)/include/$(PROJ).h \
+		$(DESTDIR)$(PREFIX)/share/$(PROJ)/$(PROJ).{c,h} \
+		$(DESTDIR)$(PREFIX)/lib/lib$(PROJ).{so,a}


### PR DESCRIPTION
- Out-of-Tree builds (defaults to ./build, configurable via DIST)
- Install and uninstall rules (which respect DESTDIR and PREFIX)
- Production of static and dynamic libraries
- Testing of all three methods of inclusion
    - direct file inclusion
    - static library
    - dynamic library (using LD_LIBRARY_PATH)
- Better declaration of PHONY targets
- Expose ability to override CC and CFLAGS