### PR TITLE
Allow ad-hoc internal parsers to be created from underscored rule names

### DIFF
--- a/mpc.h
+++ b/mpc.h
@@ -96,6 +96,7 @@ mpc_parser_t *mpc_undefine(mpc_parser_t *p);
 
 void mpc_delete(mpc_parser_t *p);
 void mpc_cleanup(int n, ...);
+void mpc_cleanup_internal(int len, mpc_parser_t **arr);
 
 /*
 ** Basic Parsers
@@ -358,7 +359,7 @@ enum {
 
 mpc_parser_t *mpca_grammar(int flags, const char *grammar, ...);
 
-mpc_err_t *mpca_lang(int flags, const char *language, ...);
+mpc_err_t *mpca_lang(int flags, mpc_parser_t ***internals, int *num_internal, const char *language, ...);
 mpc_err_t *mpca_lang_file(int flags, FILE *f, ...);
 mpc_err_t *mpca_lang_pipe(int flags, FILE *f, ...);
 mpc_err_t *mpca_lang_contents(int flags, const char *filename, ...);


### PR DESCRIPTION
Consider something like the following, where the goal is just to parse any number:

```c
mpc_parser_t* Float = mpc_new("float");
mpc_parser_t* Int = mpc_new("int");
mpc_parser_t* Number = mpc_new("number");

mpca_lang(MPCA_LANG_DEFAULT,
  "                                     \
    float   :  /-?[0-9]*\\.[0-9]+/;  \
    int     :  /-?[0-9]+/;              \
    number  :  <float> | <int>;         \
  ",
  Float, Int, Number
);
```
It's handy to maintain a distinction between the `float` and `int` rules in the grammar, but at the end of the day I might not particularly care about the actual `Float` and `Int` parsers: all I want is `Number`, but I'm forced to define the other two anyway.

Instead, this change lets the user do this:

```c
mpc_parser_t* Number = mpc_new("number");

mpca_lang(MPCA_LANG_DEFAULT,
  "                                     \
    _float  :  /-?([0-9]*)?\\.[0-9]+/;  \
    _int    :  /-?[0-9]+/;              \
    number  :  <_float> | <_int>;       \
  ",
  Number
);
```
Any underscore-initial rulename has its parser created mpc-internally, without making the user have to do it. It's a simple change but worth it, I think.