### PR TITLE
Fix backtracing bug with mpc_parse_pipe

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -320,6 +320,7 @@ static void mpc_input_mark(mpc_input_t *i) {
 }
 
 static void mpc_input_unmark(mpc_input_t *i) {
+  int j;
 
   if (i->backtrack < 1) { return; }
 
@@ -335,6 +336,9 @@ static void mpc_input_unmark(mpc_input_t *i) {
   }
 
   if (i->type == MPC_INPUT_PIPE && i->marks_num == 0) {
+    for (j = strlen(i->buffer) - 1; j >= 0; j--)
+      ungetc(i->buffer[j], i->file);
+
     free(i->buffer);
     i->buffer = NULL;
   }


### PR DESCRIPTION
I can't claim that I really understood this bug in its entirety but it seems
to me that the pipe buffer is freed when no marks are left with the assumption
that the original input can afterwards be read from the underlying stream
which isn't the case on a pipe.

Before we free our buffer we therefore need to reset the underlying stream
to its original state by pushing the buffer contents back onto the input
stream.

Fixes #109