### PR TITLE
Fix 12 dependency issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,27 +26,27 @@ check: test-file test-static test-dynamic
 	LD_LIBRARY_PATH=$(DIST) ./$(DIST)/test-dynamic
 
 test-file: $(DIST) $(TESTS) $(PROJ).c mpc.h tests/ptest.h
-        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
 
 test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so mpc.h tests/ptest.h
-        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
 
 test-static: $(DIST) $(TESTS) lib$(PROJ).a mpc.h tests/ptest.h
-        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
 
 examples/%: $(DIST) examples/%.c $(PROJ).c mpc.h
-        $(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
+	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
 
 lib$(PROJ).so: $(DIST) $(PROJ).c mpc.h
 ifneq ($(OS),Windows_NT)
-        $(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 else
-        $(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+	$(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 endif
 
 lib$(PROJ).a: $(DIST) $(PROJ).c mpc.h
-        $(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
-        $(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
+	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
+	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
 libs: lib$(PROJ).so lib$(PROJ).a
   

--- a/Makefile
+++ b/Makefile
@@ -25,28 +25,28 @@ check: test-file test-static test-dynamic
 	./$(DIST)/test-static
 	LD_LIBRARY_PATH=$(DIST) ./$(DIST)/test-dynamic
 
-test-file: $(DIST) $(TESTS) $(PROJ).c
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
+test-file: $(DIST) $(TESTS) $(PROJ).c mpc.h tests/ptest.h
+        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
 
-test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
+test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so mpc.h tests/ptest.h
+        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
 
-test-static: $(DIST) $(TESTS) lib$(PROJ).a
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
+test-static: $(DIST) $(TESTS) lib$(PROJ).a mpc.h tests/ptest.h
+        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
 
-examples/%: $(DIST) examples/%.c $(PROJ).c
-	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
+examples/%: $(DIST) examples/%.c $(PROJ).c mpc.h
+        $(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
 
-lib$(PROJ).so: $(DIST) $(PROJ).c
+lib$(PROJ).so: $(DIST) $(PROJ).c mpc.h
 ifneq ($(OS),Windows_NT)
-	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+        $(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 else
-	$(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+        $(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 endif
 
-lib$(PROJ).a: $(DIST) $(PROJ).c
-	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
-	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
+lib$(PROJ).a: $(DIST) $(PROJ).c mpc.h
+        $(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
+        $(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
 libs: lib$(PROJ).so lib$(PROJ).a
   


### PR DESCRIPTION
Hi, I've fixed 12 missing dependencies reported.
Those issues can cause incorrect results when mpc is incrementally built.
For example, any changes in "mpc.h" will not cause "examples/doge" to be rebuilt, which is incorrect. The lack of "mpc.h" for the target "examples/%" can cause the incorrect build result of 7 targets, including "examples/tree_traversal", "examples/lispy", "examples/line_reader", "examples/smallc", "examples/maths", "examples/foobar" and "examples/doge".
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake