### PR TITLE
Fix incremental build problems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,27 +26,27 @@ check: test-file test-static test-dynamic
 	LD_LIBRARY_PATH=$(DIST) ./$(DIST)/test-dynamic
 
 test-file: $(DIST) $(TESTS) $(PROJ).c mpc.h tests/ptest.h
-        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
 
 test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so mpc.h tests/ptest.h
-        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
 
 test-static: $(DIST) $(TESTS) lib$(PROJ).a mpc.h tests/ptest.h
-        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
+	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
 
 examples/%: $(DIST) examples/%.c $(PROJ).c mpc.h
-        $(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
+	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
 
 lib$(PROJ).so: $(DIST) $(PROJ).c mpc.h
 ifneq ($(OS),Windows_NT)
-        $(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 else
-        $(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+	$(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 endif
 
 lib$(PROJ).a: $(DIST) $(PROJ).c mpc.h
-        $(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
-        $(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
+	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
+	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
 libs: lib$(PROJ).so lib$(PROJ).a
   

--- a/Makefile
+++ b/Makefile
@@ -20,35 +20,35 @@ all: $(EXAMPLESEXE) check
 $(DIST):
 	$(MKDIR) $(DIST)/examples
 
-check: test-file test-static test-dynamic
+check: $(DIST)/test-file $(DIST)/test-static $(DIST)/test-dynamic
 	./$(DIST)/test-file
 	./$(DIST)/test-static
 	LD_LIBRARY_PATH=$(DIST) ./$(DIST)/test-dynamic
 
-test-file: $(DIST) $(TESTS) $(PROJ).c mpc.h tests/ptest.h
+$(DIST)/test-file: $(TESTS) $(PROJ).c mpc.h tests/ptest.h
 	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
 
-test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so mpc.h tests/ptest.h
+$(DIST)/test-dynamic: $(TESTS) $(DIST)/lib$(PROJ).so mpc.h tests/ptest.h
 	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
 
-test-static: $(DIST) $(TESTS) lib$(PROJ).a mpc.h tests/ptest.h
+$(DIST)/test-static: $(TESTS) $(DIST)/lib$(PROJ).a mpc.h tests/ptest.h
 	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
 
 examples/%: $(DIST) examples/%.c $(PROJ).c mpc.h
 	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
 
-lib$(PROJ).so: $(DIST) $(PROJ).c mpc.h
+$(DIST)/lib$(PROJ).so: $(PROJ).c mpc.h
 ifneq ($(OS),Windows_NT)
 	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 else
 	$(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 endif
 
-lib$(PROJ).a: $(DIST) $(PROJ).c mpc.h
+$(DIST)/lib$(PROJ).a: $(PROJ).c mpc.h
 	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
 	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
-libs: lib$(PROJ).so lib$(PROJ).a
+libs: $(DIST)/lib$(PROJ).so $(DIST)/lib$(PROJ).a
   
 clean:
 	rm -rf -- $(DIST)

--- a/Makefile
+++ b/Makefile
@@ -25,28 +25,28 @@ check: test-file test-static test-dynamic
 	./$(DIST)/test-static
 	LD_LIBRARY_PATH=$(DIST) ./$(DIST)/test-dynamic
 
-test-file: $(DIST) $(TESTS) $(PROJ).c
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
+test-file: $(DIST) $(TESTS) $(PROJ).c mpc.h tests/ptest.h
+        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) $(PROJ).c -lm -o $(DIST)/test-file
 
-test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
+test-dynamic: $(DIST) $(TESTS) lib$(PROJ).so mpc.h tests/ptest.h
+        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -o $(DIST)/test-dynamic
 
-test-static: $(DIST) $(TESTS) lib$(PROJ).a
-	$(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
+test-static: $(DIST) $(TESTS) lib$(PROJ).a mpc.h tests/ptest.h
+        $(CC) $(filter-out -Werror, $(CFLAGS)) $(TESTS) -lm -L$(DIST) -l$(PROJ) -static -o $(DIST)/test-static
 
-examples/%: $(DIST) examples/%.c $(PROJ).c
-	$(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
+examples/%: $(DIST) examples/%.c $(PROJ).c mpc.h
+        $(CC) $(CFLAGS) $(filter-out $(DIST), $^) -lm -o $(DIST)/$@
 
-lib$(PROJ).so: $(DIST) $(PROJ).c
+lib$(PROJ).so: $(DIST) $(PROJ).c mpc.h
 ifneq ($(OS),Windows_NT)
-	$(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+        $(CC) $(CFLAGS) -fPIC -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 else
-	$(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
+        $(CC) $(CFLAGS) -shared $(PROJ).c -o $(DIST)/lib$(PROJ).so
 endif
 
-lib$(PROJ).a: $(DIST) $(PROJ).c
-	$(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
-	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
+lib$(PROJ).a: $(DIST) $(PROJ).c mpc.h
+        $(CC) $(CFLAGS) -c $(PROJ).c -o $(DIST)/$(PROJ).o
+        $(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
 libs: lib$(PROJ).so lib$(PROJ).a
   


### PR DESCRIPTION
Hi. 
We've fixed several issues in the Makefile that prevents incremental build to be in use. 
With the original Makefile, every time we type “make test-file”, all the libmpc.so libmpc.a will be rebuilt no matter whether they are going to be used. 

With the new Makefile, each target has the correct dependencies and incremental can be correctly triggered. 