### PR TITLE
Removed trailing whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ $(DIST)/lib$(PROJ).a: $(PROJ).c mpc.h
 	$(AR) rcs $(DIST)/lib$(PROJ).a $(DIST)/$(PROJ).o
 
 libs: $(DIST)/lib$(PROJ).so $(DIST)/lib$(PROJ).a
-  
+
 clean:
 	rm -rf -- $(DIST)
 

--- a/mpc.c
+++ b/mpc.c
@@ -497,28 +497,28 @@ static int mpc_input_range(mpc_input_t *i, char c, char d, char **o) {
   char x;
   if (mpc_input_terminated(i)) { return 0; }
   x = mpc_input_getc(i);
-  return x >= c && x <= d ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);  
+  return x >= c && x <= d ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);
 }
 
 static int mpc_input_oneof(mpc_input_t *i, const char *c, char **o) {
   char x;
   if (mpc_input_terminated(i)) { return 0; }
   x = mpc_input_getc(i);
-  return strchr(c, x) != 0 ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);  
+  return strchr(c, x) != 0 ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);
 }
 
 static int mpc_input_noneof(mpc_input_t *i, const char *c, char **o) {
   char x;
   if (mpc_input_terminated(i)) { return 0; }
   x = mpc_input_getc(i);
-  return strchr(c, x) == 0 ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);  
+  return strchr(c, x) == 0 ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);
 }
 
 static int mpc_input_satisfy(mpc_input_t *i, int(*cond)(char), char **o) {
   char x;
   if (mpc_input_terminated(i)) { return 0; }
   x = mpc_input_getc(i);
-  return cond(x) ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);  
+  return cond(x) ? mpc_input_success(i, x, o) : mpc_input_failure(i, x);
 }
 
 static int mpc_input_string(mpc_input_t *i, const char *c, char **o) {

--- a/mpc.h
+++ b/mpc.h
@@ -204,7 +204,7 @@ mpc_parser_t *mpc_whole(mpc_parser_t *a, mpc_dtor_t da);
 mpc_parser_t *mpc_stripl(mpc_parser_t *a);
 mpc_parser_t *mpc_stripr(mpc_parser_t *a);
 mpc_parser_t *mpc_strip(mpc_parser_t *a);
-mpc_parser_t *mpc_tok(mpc_parser_t *a); 
+mpc_parser_t *mpc_tok(mpc_parser_t *a);
 mpc_parser_t *mpc_sym(const char *s);
 mpc_parser_t *mpc_total(mpc_parser_t *a, mpc_dtor_t da);
 
@@ -275,7 +275,7 @@ enum {
 
 mpc_parser_t *mpc_re(const char *re);
 mpc_parser_t *mpc_re_mode(const char *re, int mode);
-  
+
 /*
 ** AST
 */
@@ -373,8 +373,8 @@ void mpc_optimise(mpc_parser_t *p);
 void mpc_stats(mpc_parser_t *p);
 
 int mpc_test_pass(mpc_parser_t *p, const char *s, const void *d,
-  int(*tester)(const void*, const void*), 
-  mpc_dtor_t destructor, 
+  int(*tester)(const void*, const void*),
+  mpc_dtor_t destructor,
   void(*printer)(const void*));
 
 int mpc_test_fail(mpc_parser_t *p, const char *s, const void *d,

--- a/tests/core.c
+++ b/tests/core.c
@@ -12,7 +12,7 @@ static void strprint(const void* x) { printf("'%s'", (char*)x); }
 void test_ident(void) {
 
   /* ^[a-zA-Z_][a-zA-Z0-9_]*$ */
-  
+
   mpc_parser_t* Ident = mpc_whole(
     mpc_and(2, mpcf_strfold,
       mpc_or(2, mpc_alpha(), mpc_underscore()),
@@ -20,7 +20,7 @@ void test_ident(void) {
       free),
     free
   );
-  
+
   PT_ASSERT(mpc_test_pass(Ident, "test", "test", streq, free, strprint));
   PT_ASSERT(mpc_test_fail(Ident, "  blah", "", streq, free, strprint));
   PT_ASSERT(mpc_test_pass(Ident, "anoth21er", "anoth21er", streq, free, strprint));
@@ -28,99 +28,99 @@ void test_ident(void) {
   PT_ASSERT(mpc_test_fail(Ident, "some spaces", "", streq, free, strprint));
   PT_ASSERT(mpc_test_fail(Ident, "", "", streq, free, strprint));
   PT_ASSERT(mpc_test_fail(Ident, "18nums", "", streq, free, strprint));
-  
+
   mpc_delete(Ident);
 
 }
 
 void test_maths(void) {
-  
-  mpc_parser_t *Expr, *Factor, *Term, *Maths; 
+
+  mpc_parser_t *Expr, *Factor, *Term, *Maths;
   int r0 = 1, r1 = 5, r2 = 13, r3 = 0, r4 = 2;
-  
+
   Expr   = mpc_new("expr");
   Factor = mpc_new("factor");
   Term   = mpc_new("term");
   Maths  = mpc_new("maths");
 
-  mpc_define(Expr, mpc_or(2, 
+  mpc_define(Expr, mpc_or(2,
     mpc_and(3, mpcf_maths, Factor, mpc_oneof("*/"), Factor, free, free),
     Factor
   ));
-  
-  mpc_define(Factor, mpc_or(2, 
+
+  mpc_define(Factor, mpc_or(2,
     mpc_and(3, mpcf_maths, Term, mpc_oneof("+-"), Term, free, free),
     Term
   ));
-  
-  mpc_define(Term, mpc_or(2, 
+
+  mpc_define(Term, mpc_or(2,
     mpc_int(),
     mpc_parens(Expr, free)
   ));
-  
+
   mpc_define(Maths, mpc_whole(Expr, free));
-  
+
   PT_ASSERT(mpc_test_pass(Maths, "1", &r0, int_eq, free, int_print));
   PT_ASSERT(mpc_test_pass(Maths, "(5)", &r1, int_eq, free, int_print));
   PT_ASSERT(mpc_test_pass(Maths, "(4*2)+5", &r2, int_eq, free, int_print));
   PT_ASSERT(mpc_test_fail(Maths, "a", &r3, int_eq, free, int_print));
   PT_ASSERT(mpc_test_fail(Maths, "2b+4", &r4, int_eq, free, int_print));
-  
+
   mpc_cleanup(4, Expr, Factor, Term, Maths);
 }
 
 void test_strip(void) {
-  
+
   mpc_parser_t *Stripperl = mpc_apply(mpc_many(mpcf_strfold, mpc_any()), mpcf_strtriml);
   mpc_parser_t *Stripperr = mpc_apply(mpc_many(mpcf_strfold, mpc_any()), mpcf_strtrimr);
   mpc_parser_t *Stripper  = mpc_apply(mpc_many(mpcf_strfold, mpc_any()), mpcf_strtrim);
-  
+
   PT_ASSERT(mpc_test_pass(Stripperl, " asdmlm dasd  ", "asdmlm dasd  ", streq, free, strprint));
   PT_ASSERT(mpc_test_pass(Stripperr, " asdmlm dasd  ", " asdmlm dasd", streq, free, strprint));
   PT_ASSERT(mpc_test_pass(Stripper,  " asdmlm dasd  ", "asdmlm dasd", streq, free, strprint));
-  
+
   mpc_delete(Stripperl);
   mpc_delete(Stripperr);
   mpc_delete(Stripper);
-  
+
 }
 
 void test_repeat(void) {
-  
+
   int success;
   mpc_result_t r;
   mpc_parser_t *p = mpc_count(3, mpcf_strfold, mpc_digit(), free);
-  
+
   success = mpc_parse("test", "046", p, &r);
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "046");
   free(r.output);
-  
+
   success = mpc_parse("test", "046aa", p, &r);
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "046");
   free(r.output);
-  
+
   success = mpc_parse("test", "04632", p, &r);
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "046");
   free(r.output);
-  
+
   success = mpc_parse("test", "04", p, &r);
   PT_ASSERT(!success);
   mpc_err_delete(r.error);
-  
+
   mpc_delete(p);
-  
+
 }
 
 void test_copy(void) {
-  
+
   int success;
   mpc_result_t r;
   mpc_parser_t* p = mpc_or(2, mpc_char('a'), mpc_char('b'));
   mpc_parser_t* q = mpc_and(2, mpcf_strfold, p, mpc_copy(p), free);
-  
+
   success = mpc_parse("test", "aa", q, &r);
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "aa");
@@ -130,26 +130,26 @@ void test_copy(void) {
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "bb");
   free(r.output);
-  
+
   success = mpc_parse("test", "ab", q, &r);
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "ab");
   free(r.output);
-  
+
   success = mpc_parse("test", "ba", q, &r);
   PT_ASSERT(success);
   PT_ASSERT_STR_EQ(r.output, "ba");
   free(r.output);
-  
+
   success = mpc_parse("test", "c", p, &r);
   PT_ASSERT(!success);
   mpc_err_delete(r.error);
-  
+
   mpc_delete(mpc_copy(p));
   mpc_delete(mpc_copy(q));
-  
+
   mpc_delete(q);
-  
+
 }
 
 static int line_count = 0;
@@ -162,23 +162,23 @@ static mpc_val_t* read_line(mpc_val_t* line) {
 void test_reader(void) {
 
   mpc_parser_t* Line = mpc_many(
-    mpcf_strfold, 
+    mpcf_strfold,
     mpc_apply(mpc_re("[^\\n]*(\\n|$)"), read_line));
-  
+
   line_count = 0;
 
-  PT_ASSERT(mpc_test_pass(Line, 
-    "hello\nworld\n\nthis\nis\ndan", 
+  PT_ASSERT(mpc_test_pass(Line,
+    "hello\nworld\n\nthis\nis\ndan",
     "hello\nworld\n\nthis\nis\ndan", streq, free, strprint));
-  
+
   PT_ASSERT(line_count == 6);
-  
+
   line_count = 0;
-  
-  PT_ASSERT(mpc_test_pass(Line, 
-    "abcHVwufvyuevuy3y436782\n\n\nrehre\nrew\n-ql.;qa\neg", 
+
+  PT_ASSERT(mpc_test_pass(Line,
+    "abcHVwufvyuevuy3y436782\n\n\nrehre\nrew\n-ql.;qa\neg",
     "abcHVwufvyuevuy3y436782\n\n\nrehre\nrew\n-ql.;qa\neg", streq, free, strprint));
-  
+
   PT_ASSERT(line_count == 7);
 
   mpc_delete(Line);
@@ -194,32 +194,32 @@ static mpc_val_t *print_token(mpc_val_t *x) {
 }
 
 void test_tokens(void) {
-  
+
   mpc_parser_t* Tokens = mpc_many(
-    mpcf_strfold, 
+    mpcf_strfold,
     mpc_apply(mpc_strip(mpc_re("\\s*([a-zA-Z_]+|[0-9]+|,|\\.|:)")), print_token));
-  
+
   token_count = 0;
 
-  PT_ASSERT(mpc_test_pass(Tokens, 
-    "  hello 4352 ,  \n foo.bar   \n\n  test:ing   ", 
+  PT_ASSERT(mpc_test_pass(Tokens,
+    "  hello 4352 ,  \n foo.bar   \n\n  test:ing   ",
     "hello4352,foo.bartest:ing", streq, free, strprint));
-  
+
   PT_ASSERT(token_count == 9);
 
   mpc_delete(Tokens);
-  
+
 }
 
 void test_eoi(void) {
-  
+
   mpc_parser_t* Line = mpc_re("[^\\n]*$");
-  
+
   PT_ASSERT(mpc_test_pass(Line, "blah", "blah", streq, free, strprint));
   PT_ASSERT(mpc_test_pass(Line, "blah\n", "blah\n", streq, free, strprint));
-  
+
   mpc_delete(Line);
-  
+
 }
 
 void suite_core(void) {

--- a/tests/ptest.c
+++ b/tests/ptest.c
@@ -35,7 +35,7 @@ enum {
   YELLOW  = 6,
   WHITE   = 7,
   GRAY    = 8,
-  
+
   LIGHT_BLUE   = 9,
   LIGHT_GREEN  = 10,
   LIGHT_AQUA   = 11,
@@ -43,7 +43,7 @@ enum {
   LIGHT_PURPLE = 13,
   LIGHT_YELLOW = 14,
   LIGHT_WHITE  = 15,
-  
+
   DEFAULT      = 16
 };
 
@@ -55,16 +55,16 @@ static WORD defaults;
 static int defaults_loaded = 0;
 
 static void pt_color(int color) {
-  
+
   HANDLE cnsl = GetStdHandle(STD_OUTPUT_HANDLE);
-  
+
   if (!defaults_loaded) {
     CONSOLE_SCREEN_BUFFER_INFO info;
     GetConsoleScreenBufferInfo(cnsl, &info);
     defaults = info.wAttributes;
     defaults_loaded = 1;
   }
-  
+
   SetConsoleTextAttribute(cnsl, color == DEFAULT ? defaults : color);
 }
 
@@ -90,7 +90,7 @@ static const char* colors[] = {
   "\x1B[39m",
 };
 
-static void pt_color(int color) {  
+static void pt_color(int color) {
   printf("%s", colors[color]);
 }
 
@@ -107,27 +107,27 @@ static char assert_err_buff[MAX_ERROR];
 static int assert_err_num = 0;
 
 void pt_assert_run(int result, const char* expr, const char* file, int line) {
-  
+
   num_asserts++;
   test_passing = test_passing && result;
-  
+
   if (result) {
     num_assert_passes++;
   } else {
-    sprintf(assert_err_buff, 
-      "        %i. Assert [ %s ] (%s:%i)\n", 
+    sprintf(assert_err_buff,
+      "        %i. Assert [ %s ] (%s:%i)\n",
       assert_err_num+1, expr, file, line );
     strcat(assert_err, assert_err_buff);
     assert_err_num++;
     num_assert_fails++;
   }
-  
+
 }
 
 static void ptest_signal(int sig) {
 
   test_passing = 0;
-  
+
   switch( sig ) {
     case SIGFPE:  sprintf(assert_err_buff,
       "        %i. Division by Zero\n", assert_err_num+1);
@@ -140,18 +140,18 @@ static void ptest_signal(int sig) {
     break;
     default: break;
   }
-  
+
   assert_err_num++;
   strcat(assert_err, assert_err_buff);
-  
-  pt_color(RED); 
+
+  pt_color(RED);
   printf("Failed! \n\n%s\n", assert_err);
   pt_color(DEFAULT);
-  
+
   puts("    | Stopping Execution.");
   fflush(stdout);
   exit(0);
-  
+
 }
 
 /* Tests */
@@ -160,27 +160,27 @@ static void pt_title_case(char* output, const char* input) {
 
   int space = 1;
   unsigned int i;
-  
+
   strcpy(output, input);
-  
+
   for(i = 0; i < strlen(output); i++) {
 
     if (output[i] == '_' || output[i] == ' ') {
       space = 1;
       output[i] = ' ';
       continue;
-    } 
-    
+    }
+
     if (space && output[i] >= 'a' && output[i] <= 'z') {
       space = 0;
       output[i] = output[i] - 32;
       continue;
     }
-    
+
     space = 0;
-    
+
   }
-  
+
 }
 
 typedef struct {
@@ -200,24 +200,24 @@ void pt_add_test(void (*func)(void), const char* name, const char* suite) {
   test_t test;
 
   if (num_tests == MAX_TESTS) {
-    printf("ERROR: Exceeded maximum test count of %i!\n", 
+    printf("ERROR: Exceeded maximum test count of %i!\n",
       MAX_TESTS); abort();
   }
-  
+
   if (strlen(name) >= MAX_NAME) {
-    printf("ERROR: Test name '%s' too long (Maximum is %i characters)\n", 
+    printf("ERROR: Test name '%s' too long (Maximum is %i characters)\n",
       name, MAX_NAME); abort();
   }
-  
+
   if (strlen(suite) >= MAX_NAME) {
-    printf("ERROR: Test suite '%s' too long (Maximum is %i characters)\n", 
+    printf("ERROR: Test suite '%s' too long (Maximum is %i characters)\n",
       suite, MAX_NAME); abort();
   }
-  
+
   test.func = func;
   pt_title_case(test.name, name);
   pt_title_case(test.suite, suite);
-  
+
   tests[num_tests] = test;
   num_tests++;
 }
@@ -239,7 +239,7 @@ static clock_t start, end;
 static char current_suite[MAX_NAME];
 
 int pt_run(void) {
-  
+
   int i;
   double total;
   test_t test;
@@ -252,18 +252,18 @@ int pt_run(void) {
   puts("    |                                           |");
   puts("    | Daniel Holden (contact@theorangeduck.com) |");
   puts("    +-------------------------------------------+");
-  
+
   signal(SIGFPE,  ptest_signal);
   signal(SIGILL,  ptest_signal);
   signal(SIGSEGV, ptest_signal);
-  
+
   start = clock();
   strcpy(current_suite, "");
-  
+
   for(i = 0; i < num_tests; i++) {
 
     test = tests[i];
-    
+
     /* Check for transition to a new suite */
     if (strcmp(test.suite, current_suite)) {
 
@@ -275,25 +275,25 @@ int pt_run(void) {
           num_suites_fails++;
         }
       }
-    
+
       suite_passing = 1;
       strcpy(current_suite, test.suite);
       printf("\n\n  ===== %s =====\n\n", current_suite);
     }
-    
+
     /* Run Test */
-    
+
     test_passing = 1;
     strcpy(assert_err, "");
     strcpy(assert_err_buff, "");
     assert_err_num = 0;
     printf("    | %s ... ", test.name);
     fflush(stdout);
-    
+
     test.func();
-    
+
     suite_passing = suite_passing && test_passing;
-    
+
     if (test_passing) {
       num_tests_passes++;
       pt_color(GREEN);
@@ -301,56 +301,56 @@ int pt_run(void) {
       pt_color(DEFAULT);
     } else {
       num_tests_fails++;
-      pt_color(RED); 
+      pt_color(RED);
       printf("Failed! \n\n%s\n", assert_err);
       pt_color(DEFAULT);
     }
-    
+
   }
-  
+
   if (suite_passing) {
     num_suites_passes++;
   } else {
     num_suites_fails++;
   }
-  
+
   end = clock();
-  
+
   puts("");
   puts("  +---------------------------------------------------+");
   puts("  |                      Summary                      |");
   puts("  +---------++------------+-------------+-------------+");
-  
+
   printf("  | Suites  ||");
-  pt_color(YELLOW);  printf(" Total %4d ",  num_suites);        
+  pt_color(YELLOW);  printf(" Total %4d ",  num_suites);
   pt_color(DEFAULT); putchar('|');
-  pt_color(GREEN);   printf(" Passed %4d ", num_suites_passes); 
+  pt_color(GREEN);   printf(" Passed %4d ", num_suites_passes);
   pt_color(DEFAULT); putchar('|');
-  pt_color(RED);     printf(" Failed %4d ", num_suites_fails);  
+  pt_color(RED);     printf(" Failed %4d ", num_suites_fails);
   pt_color(DEFAULT); puts("|");
-  
+
   printf("  | Tests   ||");
-  pt_color(YELLOW);  printf(" Total %4d ",  num_tests);         
+  pt_color(YELLOW);  printf(" Total %4d ",  num_tests);
   pt_color(DEFAULT); putchar('|');
-  pt_color(GREEN);   printf(" Passed %4d ", num_tests_passes);  
+  pt_color(GREEN);   printf(" Passed %4d ", num_tests_passes);
   pt_color(DEFAULT); putchar('|');
-  pt_color(RED);     printf(" Failed %4d ", num_tests_fails);   
+  pt_color(RED);     printf(" Failed %4d ", num_tests_fails);
   pt_color(DEFAULT); puts("|");
-  
+
   printf("  | Asserts ||");
-  pt_color(YELLOW);  printf(" Total %4d ",  num_asserts);       
+  pt_color(YELLOW);  printf(" Total %4d ",  num_asserts);
   pt_color(DEFAULT); putchar('|');
-  pt_color(GREEN);   printf(" Passed %4d ", num_assert_passes); 
+  pt_color(GREEN);   printf(" Passed %4d ", num_assert_passes);
   pt_color(DEFAULT); putchar('|');
-  pt_color(RED);     printf(" Failed %4d ", num_assert_fails);  
+  pt_color(RED);     printf(" Failed %4d ", num_assert_fails);
   pt_color(DEFAULT); puts("|");
-  
+
   puts("  +---------++------------+-------------+-------------+");
   puts("");
-  
+
   total = (double)(end - start) / CLOCKS_PER_SEC;
-  
+
   printf("      Total Running Time: %0.3fs\n\n", total);
-  
+
   if (num_suites_fails > 0) { return 1; } else { return 0; }
 }

--- a/tests/regex.c
+++ b/tests/regex.c
@@ -25,7 +25,7 @@ void test_regex_basic(void) {
   re3 = mpc_re("abc(abdd)?");
   re4 = mpc_re("ab|c(abdd)?");
   re5 = mpc_re("abc(ab|dd)+g$");
-  
+
   PT_ASSERT(regex_test_pass(re0, "abc", "abc"));
   PT_ASSERT(regex_test_pass(re0, "bcd", "bcd"));
   PT_ASSERT(regex_test_fail(re0, "bc", "bc"));
@@ -35,7 +35,7 @@ void test_regex_basic(void) {
   PT_ASSERT(regex_test_pass(re2, "abcabab", "abcabab"));
   PT_ASSERT(regex_test_pass(re2, "abcababd", "abcabab"));
   PT_ASSERT(regex_test_pass(re5, "abcddg", "abcddg"));
-  
+
   mpc_delete(re0);
   mpc_delete(re1);
   mpc_delete(re2);
@@ -57,47 +57,47 @@ void test_regex_boundary(void) {
   PT_ASSERT(regex_test_pass(re0, "foo.", "foo"));
   PT_ASSERT(regex_test_pass(re0, "foo)", "foo"));
   PT_ASSERT(regex_test_pass(re0, "foo baz", "foo"));
-  
+
   PT_ASSERT(regex_test_fail(re0, "foobar", "foo"));
   PT_ASSERT(regex_test_fail(re0, "foo3", "foo"));
-  
+
   PT_ASSERT(regex_test_pass(re1, "foo", "foo"));
   PT_ASSERT(regex_test_pass(re1, " foo", " foo"));
   PT_ASSERT(regex_test_fail(re1, "wfoo", "foo"));
-  
+
   PT_ASSERT(regex_test_pass(re2, "python", "python"));
   PT_ASSERT(regex_test_pass(re2, "py3", "py3"));
   PT_ASSERT(regex_test_pass(re2, "py2", "py2"));
   PT_ASSERT(regex_test_fail(re2, "py", "py"));
   PT_ASSERT(regex_test_fail(re2, "py.", "py."));
   PT_ASSERT(regex_test_fail(re2, "py!", "py!"));
-  
+
   mpc_delete(re0);
   mpc_delete(re1);
   mpc_delete(re2);
-  
+
 }
 
 void test_regex_range(void) {
 
   mpc_parser_t *re0, *re1, *re2, *re3;
-  
+
   re0 = mpc_re("abg[abcdef]");
   re1 = mpc_re("y*[a-z]");
   re2 = mpc_re("zz(p+)?[A-Z_0\\]123]*");
   re3 = mpc_re("^[^56hy].*$");
-  
+
   /* TODO: Testing */
-  
+
   mpc_delete(re0);
   mpc_delete(re1);
   mpc_delete(re2);
   mpc_delete(re3);
-  
+
 }
 
 void test_regex_string(void) {
-  
+
   mpc_parser_t *re0 = mpc_re("\"(\\\\.|[^\"])*\"");
 
   PT_ASSERT(regex_test_pass(re0, "\"there\"", "\"there\""));
@@ -110,26 +110,26 @@ void test_regex_string(void) {
 }
 
 void test_regex_lisp_comment(void) {
-  
+
   mpc_parser_t *re0 = mpc_re(";[^\\n\\r]*");
 
   PT_ASSERT(regex_test_pass(re0, ";comment", ";comment"));
   PT_ASSERT(regex_test_pass(re0, ";i am the\nman", ";i am the"));
-  
+
   mpc_delete(re0);
-  
+
 }
 
 void test_regex_newline(void) {
-  
+
   mpc_parser_t *re0 = mpc_re("[a-z]*");
 
   PT_ASSERT(regex_test_pass(re0, "hi", "hi"));
   PT_ASSERT(regex_test_pass(re0, "hi\nk", "hi"));
   PT_ASSERT(regex_test_fail(re0, "hi\nk", "hi\nk"));
-  
+
   mpc_delete(re0);
-  
+
 }
 
 void test_regex_multiline(void) {
@@ -142,13 +142,13 @@ void test_regex_multiline(void) {
   PT_ASSERT(regex_test_fail(re0, "45234", "45234"));
   PT_ASSERT(regex_test_fail(re0, "\n45234", "\n45234"));
   PT_ASSERT(regex_test_pass(re0, "\n45234", "\n"));
-  
+
   mpc_delete(re0);
-  
+
 }
 
 void test_regex_dotall(void) {
-  
+
   mpc_parser_t *re0 = mpc_re_mode("^.*$", MPC_RE_DEFAULT);
   mpc_parser_t *re1 = mpc_re_mode("^.*$", MPC_RE_DOTALL);
 
@@ -157,16 +157,16 @@ void test_regex_dotall(void) {
   PT_ASSERT(regex_test_fail(re0, "he\nllo\n", "he"));
   PT_ASSERT(regex_test_pass(re0, "34njaksdklmasd", "34njaksdklmasd"));
   PT_ASSERT(regex_test_fail(re0, "34njaksd\nklmasd", "34njaksd"));
-  
+
   PT_ASSERT(regex_test_pass(re1, "hello", "hello"));
   PT_ASSERT(regex_test_pass(re1, "hello\n", "hello\n"));
   PT_ASSERT(regex_test_pass(re1, "he\nllo\n", "he\nllo\n"));
   PT_ASSERT(regex_test_pass(re1, "34njaksdklmasd", "34njaksdklmasd"));
   PT_ASSERT(regex_test_pass(re1, "34njaksd\nklmasd", "34njaksd\nklmasd"));
-  
+
   mpc_delete(re0);
   mpc_delete(re1);
-  
+
 }
 
 void suite_regex(void) {


### PR DESCRIPTION
Ran across some trailing whitespace when reading the code in an editor.  Sending this patch in the hope that it's helpful.  Thanks for sharing this library and the lispy tutorial.