### PR TITLE
mpc.h: Add prototype for mpcf_freefold

### DIFF
--- a/mpc.h
+++ b/mpc.h
@@ -258,6 +258,7 @@ mpc_val_t *mpcf_snd_free(int n, mpc_val_t** xs);
 mpc_val_t *mpcf_trd_free(int n, mpc_val_t** xs);
 mpc_val_t *mpcf_all_free(int n, mpc_val_t** xs);
 
+mpc_val_t *mpcf_freefold(int n, mpc_val_t** xs);
 mpc_val_t *mpcf_strfold(int n, mpc_val_t** xs);
 mpc_val_t *mpcf_maths(int n, mpc_val_t** xs);
 


### PR DESCRIPTION
The mpcf_freefold is documented in the README but currently not declared
in the header file. As such, adding the latter was probably just
forgotten at some point. This change adds the required function
prototype.

---

BTW: Compiling with `-Wstrict-prototypes` would allow catching such errors.