### PR TITLE
Fix `-Wformat-overflow` warnings due to gcc 12 + ASAN + `-O2`

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -863,6 +863,9 @@ static mpc_err_t *mpc_err_count(mpc_input_t *i, mpc_err_t *x, int n) {
   int digits = n/10 + 1;
   char *prefix;
   prefix = mpc_malloc(i, digits + strlen(" of ") + 1);
+  if (!prefix) {
+    return NULL;
+  }
   sprintf(prefix, "%i of ", n);
   y = mpc_err_repeat(i, x, prefix);
   mpc_free(i, prefix);
@@ -1651,6 +1654,9 @@ mpc_parser_t *mpc_failf(const char *fmt, ...) {
 
   va_start(va, fmt);
   buffer = malloc(2048);
+  if (!buffer) {
+    return NULL;
+  }
   vsprintf(buffer, fmt, va);
   va_end(va);
 
@@ -1725,6 +1731,9 @@ mpc_parser_t *mpc_expectf(mpc_parser_t *a, const char *fmt, ...) {
 
   va_start(va, fmt);
   buffer = malloc(2048);
+  if (!buffer) {
+    return NULL;
+  }
   vsprintf(buffer, fmt, va);
   va_end(va);
 


### PR DESCRIPTION
Compiling mpc with the `gcc-12` compiler in Ubuntu 22.04 (Jammy) with `-Wformat-overflow`, ASAN enabled and `-O2` i.e. with the following patch applied:

```patch
diff --git a/Makefile b/Makefile
index 7719acc..1d2706c 100644
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ PREFIX ?= /usr/local
 CFLAGS ?= $(STD) -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow \
   -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align \
   -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls \
-  -Wnested-externs -Wmissing-include-dirs -Wswitch-default
+  -Wnested-externs -Wmissing-include-dirs -Wswitch-default -Wformat-overflow \
+  -fsanitize=address,undefined -O2

 TESTS = $(wildcard tests/*.c)
 EXAMPLES = $(wildcard examples/*.c)
```

and

```bash
CC=gcc-12 make
```

results in the following output and errors:

```
mkdir -p build
mkdir -p build/examples
gcc-12 -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings
  -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition
  -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default -Wformat-overflow
  -fsanitize=address,undefined -O2 examples/doge.c mpc.c -lm -o build/examples/doge
In file included from /usr/include/stdio.h:894,
                 from mpc.h:18,
                 from mpc.c:1:
In function 'vsprintf',
    inlined from 'mpc_failf' at mpc.c:1654:3:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:52:10: error: null destination pointer [-Werror=format-overflow=]
   52 |   return __builtin___vsprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |                                    __glibc_objsize (__s), __fmt, __ap);
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'vsprintf',
    inlined from 'mpc_expectf' at mpc.c:1728:3:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:52:10: error: null destination pointer [-Werror=format-overflow=]
   52 |   return __builtin___vsprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |                                    __glibc_objsize (__s), __fmt, __ap);
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'sprintf',
    inlined from 'mpc_err_count' at mpc.c:866:3,
    inlined from 'mpc_parse_run' at mpc.c:1241:9:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:38:10: error: null destination pointer [-Werror=format-overflow=]
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:40: examples/doge] Error 1
```

This pr fixes the code with regard to those errors.