### PR TITLE
remove mpcf_maths from mpc.c and adjust maths test

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -2671,25 +2671,6 @@ mpc_val_t *mpcf_strfold(int n, mpc_val_t **xs) {
   return xs[0];
 }
 
-mpc_val_t *mpcf_maths(int n, mpc_val_t **xs) {
-  int **vs = (int**)xs;
-  (void) n;
-
-  switch(((char*)xs[1])[0])
-  {
-    case '*': { *vs[0] *= *vs[2]; }; break;
-    case '/': { *vs[0] /= *vs[2]; }; break;
-    case '%': { *vs[0] %= *vs[2]; }; break;
-    case '+': { *vs[0] += *vs[2]; }; break;
-    case '-': { *vs[0] -= *vs[2]; }; break;
-    default: break;
-  }
-
-  free(xs[1]); free(xs[2]);
-
-  return xs[0];
-}
-
 /*
 ** Printing
 */

--- a/mpc.h
+++ b/mpc.h
@@ -260,7 +260,6 @@ mpc_val_t *mpcf_all_free(int n, mpc_val_t** xs);
 
 mpc_val_t *mpcf_freefold(int n, mpc_val_t** xs);
 mpc_val_t *mpcf_strfold(int n, mpc_val_t** xs);
-mpc_val_t *mpcf_maths(int n, mpc_val_t** xs);
 
 /*
 ** Regular Expression Parsers

--- a/tests/core.c
+++ b/tests/core.c
@@ -33,6 +33,25 @@ void test_ident(void) {
 
 }
 
+static mpc_val_t *mpcf_maths(int n, mpc_val_t **xs) {
+  int **vs = (int**)xs;
+  (void) n;
+
+  switch(((char*)xs[1])[0])
+  {
+    case '*': { *vs[0] *= *vs[2]; }; break;
+    case '/': { *vs[0] /= *vs[2]; }; break;
+    case '%': { *vs[0] %= *vs[2]; }; break;
+    case '+': { *vs[0] += *vs[2]; }; break;
+    case '-': { *vs[0] -= *vs[2]; }; break;
+    default: break;
+  }
+
+  free(xs[1]); free(xs[2]);
+
+  return xs[0];
+}
+
 void test_maths(void) {
 
   mpc_parser_t *Expr, *Factor, *Term, *Maths;
@@ -44,12 +63,12 @@ void test_maths(void) {
   Maths  = mpc_new("maths");
 
   mpc_define(Expr, mpc_or(2,
-    mpc_and(3, mpcf_maths, Factor, mpc_oneof("*/"), Factor, free, free),
+    mpc_and(3, mpcf_maths, Factor, mpc_oneof("+-"), Factor, free, free),
     Factor
   ));
 
   mpc_define(Factor, mpc_or(2,
-    mpc_and(3, mpcf_maths, Term, mpc_oneof("+-"), Term, free, free),
+    mpc_and(3, mpcf_maths, Term, mpc_oneof("*/"), Term, free, free),
     Term
   ));
 
@@ -63,6 +82,7 @@ void test_maths(void) {
   PT_ASSERT(mpc_test_pass(Maths, "1", &r0, int_eq, free, int_print));
   PT_ASSERT(mpc_test_pass(Maths, "(5)", &r1, int_eq, free, int_print));
   PT_ASSERT(mpc_test_pass(Maths, "(4*2)+5", &r2, int_eq, free, int_print));
+  PT_ASSERT(mpc_test_pass(Maths, "4*2+5", &r2, int_eq, free, int_print));
   PT_ASSERT(mpc_test_fail(Maths, "a", &r3, int_eq, free, int_print));
   PT_ASSERT(mpc_test_fail(Maths, "2b+4", &r4, int_eq, free, int_print));
 


### PR DESCRIPTION
Couple of straightforward, hopefully useful, adjustments:

1. `mpcf_maths` moved from `mpc.c` to `tests/core.c`, because:
   - seems like a very specific function that should not be included in main library object
   - it is only used in the mentioned test
2. adjusted the grammar in `test_maths` to switch the set of operators for `Term` and `Expr` such that they follow the standard convention regarding precedence, in fact, now with the grammar in the test consistent with the similar grammar definition in the README.

In short, no critical adjustments, well, perhaps except for 1. in case some client code out there already happens to rely on `mpcf_maths` ... 

If this can be merged (or some of the above committed directly by any maintainers), great! if not, totally fine, too. Thanks.
