### PR TITLE
Makefile: Install the templated pkg-config file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ EXAMPLESEXE = $(EXAMPLES:.c=)
 
 .PHONY: all check clean libs $(DIST)/$(PROJ).pc
 
-all: $(EXAMPLESEXE) check
+all: $(EXAMPLESEXE) check libs $(DIST)/$(PROJ).pc
 
 $(DIST):
 	$(MKDIR) $(DIST)
@@ -65,7 +65,8 @@ install: all
 	install -m755 -t $(DESTDIR)$(PREFIX)/lib $(DIST)/lib*
 	install -m644 -t $(DESTDIR)$(PREFIX)/share/$(PROJ) $(PROJ).c $(PROJ).h
 	install -m644 $(PROJ).h $(DESTDIR)$(PREFIX)/include/$(PROJ).h
-	install -m644 $(PROJ).pc $(DESTDIR)$(PREFIX)/lib/pkgconfig/$(PROJ).pc
+	install -m644 $(DIST)/$(PROJ).pc \
+	  $(DESTDIR)$(PREFIX)/lib/pkgconfig/$(PROJ).pc
 
 uninstall:
 	rm -rf -- \


### PR DESCRIPTION
Otherwise, the 'prefix' variable would be left undefined:

   $ pkg-config --cflags mpc
   Variable 'prefix' not defined in '/gnu/store/...-profile/lib/pkgconfig/mpc.pc'

   $ cat /gnu/store/...-profile/lib/pkgconfig/mpc.pc
   libdir=${prefix}/lib
   includedir=${prefix}/include
   [...]

* Makefile (install): Install the templated pkg-config from the build directory.
(all): Add the libs and $(DIST)/$(PROJ).pc targets.