### PR TITLE
fix: pkg-config only finding mpc with sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,9 @@ clean:
 	rm -rf -- $(DIST)
 
 install: all
-	install -d -m644 $(DESTDIR)$(PREFIX)/include
-	install -d -m644 $(DESTDIR)$(PREFIX)/lib/pkgconfig
-	install -d -m644 $(DESTDIR)$(PREFIX)/share/$(PROJ)
+	install -d -m645 $(DESTDIR)$(PREFIX)/include
+	install -d -m645 $(DESTDIR)$(PREFIX)/lib/pkgconfig
+	install -d -m645 $(DESTDIR)$(PREFIX)/share/$(PROJ)
 	install -m755 -t $(DESTDIR)$(PREFIX)/lib $(DIST)/lib*
 	install -m644 -t $(DESTDIR)$(PREFIX)/share/$(PROJ) $(PROJ).c $(PROJ).h
 	install -m644 $(PROJ).h $(DESTDIR)$(PREFIX)/include/$(PROJ).h


### PR DESCRIPTION
### Problem

After running `make install`, pkg-config only finds mpc with sudo:

```
$ sudo pkg-config --list-all | grep mpc
mpc - Library for creating parser combinators

$ pkg-config --list-all | grep mpc
```

This is because the Makefile runs `install -d -m644`, which doesn't include permission to access the `/usr/local/lib/pkgconfig` directory.

### Solution

Fix this by changing the created directories mode to 645.