### PR TITLE
fix: mpc_sepby1 not applying fold correctly 

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -1046,7 +1046,7 @@ enum {
 
 #define MPC_MAX_RECURSION_DEPTH 1000
 
-static mpc_result_t *grow_results(mpc_input_t *i, int j, mpc_result_t *results_stk, mpc_result_t *results){
+static mpc_result_t *mpc_grow_results(mpc_input_t *i, int j, mpc_result_t *results_stk, mpc_result_t *results){
   mpc_result_t *tmp_results = results;
 
   if (j == MPC_PARSE_STACK_MIN) {
@@ -1190,7 +1190,7 @@ static int mpc_parse_run(mpc_input_t *i, mpc_parser_t *p, mpc_result_t *r, mpc_e
 
       while (mpc_parse_run(i, p->data.repeat.x, &results[j], e, depth+1)) {
         j++;
-        results = grow_results(i, j, results_stk, results);
+        results = mpc_grow_results(i, j, results_stk, results);
       }
 
       *e = mpc_err_merge(i, *e, results[j].error);
@@ -1205,7 +1205,7 @@ static int mpc_parse_run(mpc_input_t *i, mpc_parser_t *p, mpc_result_t *r, mpc_e
 
       while (mpc_parse_run(i, p->data.repeat.x, &results[j], e, depth+1)) {
         j++;
-        results = grow_results(i, j, results_stk, results);
+        results = mpc_grow_results(i, j, results_stk, results);
       }
 
       if (j == 0) {

--- a/tests/core.c
+++ b/tests/core.c
@@ -8,6 +8,11 @@ static int int_eq(const void* x, const void* y) { return (*(int*)x == *(int*)y);
 static void int_print(const void* x) { printf("'%i'", *((int*)x)); }
 static int streq(const void* x, const void* y) { return (strcmp(x, y) == 0); }
 static void strprint(const void* x) { printf("'%s'", (char*)x); }
+static mpc_val_t *fold_vals(int n, mpc_val_t **xs) {
+  char** vals = malloc(sizeof(char*) * n);
+  memcpy(vals, xs, sizeof(char*) * n);
+  return vals;
+}
 
 void test_ident(void) {
 
@@ -252,6 +257,19 @@ void test_sepby(void) {
   PT_ASSERT(mpc_test_pass(CommaSepIdent, "one,two,three", "onetwothree", streq, free, strprint));
 
   mpc_delete(CommaSepIdent);
+
+  mpc_parser_t* CommaSepIdent1 = mpc_sepby1(fold_vals, mpc_char(','), mpc_ident());
+  mpc_result_t r;
+
+  mpc_parse("<test>", "uno,dos,tres,cuatro", CommaSepIdent1, &r);
+  char **vals = r.output;
+  PT_ASSERT(strcmp("uno",    vals[0]) == 0);
+  PT_ASSERT(strcmp("dos",    vals[1]) == 0);
+  PT_ASSERT(strcmp("tres",   vals[2]) == 0);
+  PT_ASSERT(strcmp("cuatro", vals[3]) == 0);
+
+  free(vals);
+  mpc_delete(CommaSepIdent1);
 }
 
 void suite_core(void) {


### PR DESCRIPTION
## Problem

`mpc_sepby1` takes a single fold function but this doesn't apply to the whole list of entries. Instead it applies the fold twice, one for `mpc_and` and another for `mpc_many`. This makes it hard to build an array of structures.

Previously discussed on https://github.com/orangeduck/mpc/pull/165#discussion_r1292852737

## Solution

Introduce a new repeat repeat parser type `MPC_TYPE_SEPBY1` that combines the results and applies the fold once for all entries.