### PR TITLE
Automatic parser generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,15 +834,16 @@ This opens and reads in the contents of the file given by `filename` and passes 
 
 * * *
 
-Automatic parser generating functions:
-
-* * *
-
+### Automatic parsing
+These functions rely on the following struct:
 ```c
-mpc_err_t	*mpca_lang_auto(int flags, const char *language, mpc_auto_parsers_t **parser_refs);
+typedef struct {
+  mpc_parser_t  **parsers;
+  unsigned int  parsers_num;
+} mpc_auto_parsers_t;
 ```
 
-This creates a `mpc_auto_parsers_t` struct from a single language string, which holds all the parsers. Parsers can be retrieved by `mpc_auto_find_parser` and freed via `mpc_auto_delete`. This means that the above example can be rewritten in a much more concise way:
+The idea is that you don't have to declare parsers yourself, saving you a lot of boilerplate and cleanup. This means that the above example can be rewritten in a much more concise way:
 
 ```c
 mpc_auto_parsers_t *parsers;
@@ -867,6 +868,16 @@ if (mpc_auto_find_parser("maths", parsers, &entrypoint))
 }
 mpc_auto_delete(parsers);
 ```
+
+This gets especially visibile when you areworking with many parsers at once.
+
+* * *
+
+```c
+mpc_err_t	*mpca_lang_auto(int flags, const char *language, mpc_auto_parsers_t **parser_refs);
+```
+
+This creates a `mpc_auto_parsers_t` struct from a single language string, which holds all the parsers. Parsers can be retrieved by `mpc_auto_find_parser` and freed via `mpc_auto_delete`.
 
 * * *
 

--- a/mpc.h
+++ b/mpc.h
@@ -358,12 +358,19 @@ enum {
   MPCA_LANG_WHITESPACE_SENSITIVE = 2
 };
 
+typedef struct {
+  mpc_parser_t  **parsers;
+  unsigned int  parsers_num;
+} mpc_auto_parsers_t;
+
 mpc_parser_t *mpca_grammar(int flags, const char *grammar, ...);
 
 mpc_err_t *mpca_lang(int flags, const char *language, ...);
 mpc_err_t *mpca_lang_file(int flags, FILE *f, ...);
 mpc_err_t *mpca_lang_pipe(int flags, FILE *f, ...);
 mpc_err_t *mpca_lang_contents(int flags, const char *filename, ...);
+mpc_err_t	*mpca_lang_auto(int flags, const char *language, mpc_auto_parsers_t **parser_refs);
+mpc_err_t	*mpca_lang_auto_files(int flags, unsigned long amount, char **files, mpc_auto_parsers_t **parser_refs);
 
 /*
 ** Misc
@@ -383,6 +390,8 @@ int mpc_test_fail(mpc_parser_t *p, const char *s, const void *d,
   int(*tester)(const void*, const void*),
   mpc_dtor_t destructor,
   void(*printer)(const void*));
+int mpc_auto_find_parser(char *name, mpc_auto_parsers_t	*autoparser, mpc_parser_t **parser_ref);
+void mpc_auto_delete(mpc_auto_parsers_t *autoparser);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds the following functions:

- `mpca_lang_auto`
- `mpca_lang_auto_files`
- `mpc_auto_find_parser`
- `mpc_auto_delete`

Allows to use mpca grammar without having to spam `mpc_new`.