### PR TITLE
Fix compile issue

### DIFF
--- a/mpc.c
+++ b/mpc.c
@@ -1591,9 +1591,11 @@ mpc_parser_t *mpc_copy(mpc_parser_t *a) {
       for (i = 0; i < a->data.and.n; i++) {
         p->data.and.xs[i] = mpc_copy(a->data.and.xs[i]);
       }
-      p->data.and.dxs = malloc((a->data.and.n-1) * sizeof(mpc_dtor_t));
-      for (i = 0; i < a->data.and.n-1; i++) {
-        p->data.and.dxs[i] = a->data.and.dxs[i];
+      if (a->data.and.n > 0) {
+          p->data.and.dxs = malloc((a->data.and.n-1) * sizeof(mpc_dtor_t));
+          for (i = 0; i < a->data.and.n-1; i++) {
+            p->data.and.dxs[i] = a->data.and.dxs[i];
+          }
       }
     break;
 


### PR DESCRIPTION
Trivial change to fix an error reported by recent compiler:
```
cc -ansi -pedantic -O3 -g -Wall -Werror -Wextra -Wformat=2 -Wshadow -Wno-long-long -Wno-overlength-strings -Wno-format-nonliteral -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -Wnested-externs -Wmissing-include-dirs -Wswitch-default -c mpc.c -o build/mpc.o
mpc.c: In function ‘mpc_copy’:
mpc.c:1594:25: error: argument 1 range [18446744056529682432, 18446744073709551608] exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
 1594 |       p->data.and.dxs = malloc((a->data.and.n-1) * sizeof(mpc_dtor_t));
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from mpc.h:17,
                 from mpc.c:1:
/usr/include/stdlib.h:672:14: note: in a call to allocation function ‘malloc’ declared here
  672 | extern void *malloc (size_t __size) __THROW __attribute_malloc__
      |              ^~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:50: build/libmpc.a] Error 1
```
